### PR TITLE
Add persistent workflow pages using MongoDB

### DIFF
--- a/src/main/java/org/commonwl/viewer/domain/GithubDetails.java
+++ b/src/main/java/org/commonwl/viewer/domain/GithubDetails.java
@@ -19,10 +19,12 @@
 
 package org.commonwl.viewer.domain;
 
+import java.io.Serializable;
+
 /**
  * Represents all the parameters necessary to access a file/directory in Github
  */
-public class GithubDetails {
+public class GithubDetails implements Serializable {
 
     private String owner;
     private String repoName;

--- a/src/main/java/org/commonwl/viewer/domain/ROBundle.java
+++ b/src/main/java/org/commonwl/viewer/domain/ROBundle.java
@@ -29,6 +29,7 @@ import org.eclipse.egit.github.core.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -146,11 +147,15 @@ public class ROBundle {
 
     /**
      * Save the Research Object bundle to disk
+     * @param directory The directory in which the RO will be saved
+     * @return The path to the research object
+     * @throws IOException Any errors in saving
      */
-    public void saveToTempFile() throws IOException {
+    public Path saveToFile(Path directory) throws IOException {
         // Save the Research Object Bundle
-        Path zip = Files.createTempFile("bundle", ".zip");
-        Bundles.closeAndSaveBundle(bundle, zip);
+        Path bundleLocation = Files.createTempFile(directory, "bundle", ".zip");
+        Bundles.closeAndSaveBundle(bundle, bundleLocation);
+        return bundleLocation;
     }
 
 }

--- a/src/main/java/org/commonwl/viewer/domain/Workflow.java
+++ b/src/main/java/org/commonwl/viewer/domain/Workflow.java
@@ -43,7 +43,7 @@ public class Workflow {
 
     // ID for database
     @Id
-    private String id;
+    public String id;
 
     // Metadata
     @Indexed(unique = true)
@@ -82,6 +82,10 @@ public class Workflow {
     }
 
     public String getID() { return id; }
+
+    public void setId(String id) {
+        this.id = id;
+    }
 
     public String getLabel() {
         return label;

--- a/src/main/java/org/commonwl/viewer/domain/Workflow.java
+++ b/src/main/java/org/commonwl/viewer/domain/Workflow.java
@@ -42,11 +42,12 @@ public class Workflow {
 
     // ID for database
     @Id
-    private GithubDetails retrievedFrom;
+    private String id;
 
     // Metadata
     @DateTimeFormat(pattern="MMM d yyyy 'at' hh:mm")
     private Date retrievedOn;
+    private GithubDetails retrievedFrom;
     private Path roBundle;
 
     // Contents of the workflow
@@ -75,19 +76,7 @@ public class Workflow {
         }
     }
 
-    @Override
-    public String toString() {
-        return "Workflow{" +
-                "retrievedFrom=" + retrievedFrom +
-                ", retrievedOn=" + retrievedOn +
-                ", roBundle=" + roBundle +
-                ", label='" + label + '\'' +
-                ", doc='" + doc + '\'' +
-                ", inputs=" + inputs +
-                ", outputs=" + outputs +
-                ", dotGraph='" + dotGraph + '\'' +
-                '}';
-    }
+    public String getID() { return id; }
 
     public String getLabel() {
         return label;

--- a/src/main/java/org/commonwl/viewer/domain/Workflow.java
+++ b/src/main/java/org/commonwl/viewer/domain/Workflow.java
@@ -23,6 +23,8 @@ import org.commonwl.viewer.services.DotWriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.format.annotation.DateTimeFormat;
 
 import java.io.IOException;
@@ -31,11 +33,10 @@ import java.nio.file.Path;
 import java.util.Date;
 import java.util.Map;
 
-import static java.util.Calendar.DATE;
-
 /**
  * Representation of a workflow
  */
+@Document
 public class Workflow {
 
     static private final Logger logger = LoggerFactory.getLogger(Workflow.class);
@@ -45,10 +46,14 @@ public class Workflow {
     private String id;
 
     // Metadata
+    @Indexed(unique = true)
+    private GithubDetails retrievedFrom;
     @DateTimeFormat(pattern="MMM d yyyy 'at' hh:mm")
     private Date retrievedOn;
-    private GithubDetails retrievedFrom;
-    private Path roBundle;
+
+    // A String which represents the path to a RO bundle
+    // Path types cannot be stored using Spring Data, unfortunately
+    private String roBundle;
 
     // Contents of the workflow
     private String label;
@@ -110,11 +115,11 @@ public class Workflow {
         this.outputs = outputs;
     }
 
-    public Path getRoBundle() {
+    public String getRoBundle() {
         return roBundle;
     }
 
-    public void setRoBundle(Path roBundle) {
+    public void setRoBundle(String roBundle) {
         this.roBundle = roBundle;
     }
 

--- a/src/main/java/org/commonwl/viewer/domain/Workflow.java
+++ b/src/main/java/org/commonwl/viewer/domain/Workflow.java
@@ -42,12 +42,11 @@ public class Workflow {
 
     // ID for database
     @Id
-    private String id;
+    private GithubDetails retrievedFrom;
 
     // Metadata
     @DateTimeFormat(pattern="MMM d yyyy 'at' hh:mm")
     private Date retrievedOn;
-    private GithubDetails retrievedFrom;
     private Path roBundle;
 
     // Contents of the workflow
@@ -79,13 +78,14 @@ public class Workflow {
     @Override
     public String toString() {
         return "Workflow{" +
-                "id='" + id + '\'' +
-                ", retrievedFrom=" + retrievedFrom +
+                "retrievedFrom=" + retrievedFrom +
+                ", retrievedOn=" + retrievedOn +
                 ", roBundle=" + roBundle +
                 ", label='" + label + '\'' +
                 ", doc='" + doc + '\'' +
                 ", inputs=" + inputs +
                 ", outputs=" + outputs +
+                ", dotGraph='" + dotGraph + '\'' +
                 '}';
     }
 

--- a/src/main/java/org/commonwl/viewer/domain/Workflow.java
+++ b/src/main/java/org/commonwl/viewer/domain/Workflow.java
@@ -48,7 +48,7 @@ public class Workflow {
     // Metadata
     @Indexed(unique = true)
     private GithubDetails retrievedFrom;
-    @DateTimeFormat(pattern="MMM d yyyy 'at' hh:mm")
+    @DateTimeFormat(pattern="MMM d yyyy 'at' hh:mm z")
     private Date retrievedOn;
 
     // A String which represents the path to a RO bundle

--- a/src/main/java/org/commonwl/viewer/services/WorkflowFactory.java
+++ b/src/main/java/org/commonwl/viewer/services/WorkflowFactory.java
@@ -76,7 +76,7 @@ public class WorkflowFactory {
             } else {
                 logger.error("No workflow could be found");
             }
-        } catch (IOException ex) {
+        } catch (Exception ex) {
             logger.error(ex.getMessage());
         }
 

--- a/src/main/java/org/commonwl/viewer/web/WorkflowController.java
+++ b/src/main/java/org/commonwl/viewer/web/WorkflowController.java
@@ -30,14 +30,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindingResult;
-import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.servlet.ModelAndView;
 
 import javax.validation.Valid;
-import java.util.List;
 
 @Controller
 public class WorkflowController {
@@ -121,8 +119,12 @@ public class WorkflowController {
     public ModelAndView getWorkflow(@PathVariable String workflowID){
 
         // Get workflow from database
-        // TODO: Check exists / redirect to error page if not
         Workflow workflowModel = workflowRepository.findOne(workflowID);
+
+        // 404 error if workflow does not exist
+        if (workflowModel == null) {
+            throw new WorkflowNotFoundException();
+        }
 
         // Display this model along with the view
         return new ModelAndView("workflow", "workflow", workflowModel);

--- a/src/main/java/org/commonwl/viewer/web/WorkflowController.java
+++ b/src/main/java/org/commonwl/viewer/web/WorkflowController.java
@@ -108,7 +108,7 @@ public class WorkflowController {
             }
 
             // Redirect to the workflow
-            return new ModelAndView("redirect:/workflow/" + workflowID);
+            return new ModelAndView("redirect:/workflows/" + workflowID);
         }
     }
 
@@ -117,7 +117,7 @@ public class WorkflowController {
      * @param workflowID The ID of the workflow to be retrieved
      * @return The workflow view with the workflow as a model
      */
-    @RequestMapping(value="/workflow/{workflowID}")
+    @RequestMapping(value="/workflows/{workflowID}")
     public ModelAndView getWorkflow(@PathVariable String workflowID){
 
         // Get workflow from database

--- a/src/main/java/org/commonwl/viewer/web/WorkflowController.java
+++ b/src/main/java/org/commonwl/viewer/web/WorkflowController.java
@@ -147,8 +147,8 @@ public class WorkflowController {
         // Get workflow from database
         Workflow workflowModel = workflowRepository.findOne(workflowID);
 
-        // 404 error if workflow does not exist
-        if (workflowModel == null) {
+        // 404 error if workflow does not exist or the bundle doesn't yet
+        if (workflowModel == null || workflowModel.getRoBundle() == null) {
             throw new WorkflowNotFoundException();
         }
 
@@ -157,7 +157,7 @@ public class WorkflowController {
 
         // Serve the file from the local filesystem
         File bundleDownload = new File(workflowModel.getRoBundle());
-        logger.info("Serving download for " + bundleDownload.toString());
+        logger.info("Serving download for workflow " + workflowID + " [" + bundleDownload.toString() + "]");
         return new FileSystemResource(bundleDownload);
     }
 }

--- a/src/main/java/org/commonwl/viewer/web/WorkflowController.java
+++ b/src/main/java/org/commonwl/viewer/web/WorkflowController.java
@@ -141,8 +141,8 @@ public class WorkflowController {
                     method = RequestMethod.GET,
                     produces = "application/vnd.wf4ever.robundle+zip")
     @ResponseBody
-    public FileSystemResource getFile(@PathVariable("workflowID") String workflowID,
-                                      HttpServletResponse response) {
+    public FileSystemResource downloadROBundle(@PathVariable("workflowID") String workflowID,
+                                               HttpServletResponse response) {
 
         // Get workflow from database
         Workflow workflowModel = workflowRepository.findOne(workflowID);

--- a/src/main/java/org/commonwl/viewer/web/WorkflowNotFoundException.java
+++ b/src/main/java/org/commonwl/viewer/web/WorkflowNotFoundException.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.commonwl.viewer.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a workflow ID does not exist
+ */
+@ResponseStatus(value = HttpStatus.NOT_FOUND)
+public class WorkflowNotFoundException extends RuntimeException {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,9 @@
 applicationName = Common Workflow Language Viewer
 applicationURL = http://view.commonwl.org
 
+# Path to a directory in which the RO Bundles will be stored
+storageLocation = /tmp
+
 # File size limit for individual files in bytes
 singleFileSizeLimit = 5000000
 

--- a/src/main/resources/static/js/workflow.js
+++ b/src/main/resources/static/js/workflow.js
@@ -97,13 +97,13 @@ require(['jquery', 'bootstrap.modal', 'renderer'],
         /**
          * Downloading of the DOT graph as a .gv file
          */
-        $('#download-gv').click(function (event) {
+        $('#download-dot').click(function (event) {
             // Generate download link src
             var dotGraph = $("#dot").val();
             var src = "data:text/plain;charset=utf-8," + encodeURIComponent(dotGraph);
 
             // Set hidden download link href to contents and click it
-            var downloadLink = $("#download-link-gv");
+            var downloadLink = $("#download-link-dot");
             downloadLink.attr("href", src);
             downloadLink[0].click();
 

--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<html xmlns:th="http://www.thymeleaf.org"
+      th:include="/fragments/error :: errorpage">
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <div th:fragment="errormsg">
+            <strong>Error: </strong> The resource you requested could not be found.
+            <a href="/">Return to the homepage</a>
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<html xmlns:th="http://www.thymeleaf.org"
+      th:include="/fragments/error :: errorpage">
+    <head>
+        <title></title>
+    </head>
+    <body>
+        <div th:fragment="errormsg">
+            <strong>Error: </strong> An internal server error occurred
+        </div>
+    </body>
+</html>

--- a/src/main/resources/templates/fragments/error.html
+++ b/src/main/resources/templates/fragments/error.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~ with the License.  You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<html xmlns:th="http://www.thymeleaf.org"
+      th:fragment="errorpage">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Common Workflow Language Viewer</title>
+        <link rel="stylesheet" type="text/css" th:href="@{/css/main.css}" href="../static/css/main.css" />
+        <link rel="stylesheet" th:href="@{/bower_components/bootstrap/dist/css/bootstrap.min.css}" href="../static/bower_components/bootstrap/dist/css/bootstrap.min.css" />
+    </head>
+    <body>
+
+        <nav th:replace="/fragments/header :: navbar"></nav>
+
+        <div class="container">
+            <div class="row">
+                <div class="col-md-12" role="main" id="main">
+                    <h1>Whoops - Something Went Wrong!</h1>
+                    <div class="alert alert-danger" th:include="this :: errormsg">
+                        <strong>Error:</strong> <span>Error message here</span>
+                    </div>
+                    <p>
+                        If this error was unexpected, you can help us by
+                        <a href="https://github.com/common-workflow-language/cwlviewer/issues" rel="noopener" target="_blank">creating a Github issue</a>
+                        and/or <a href="https://gitter.im/common-workflow-language/common-workflow-language" rel="noopener" target="_blank">discussing it on Gitter</a>
+                    </p>
+                </div>
+            </div>
+        </div>
+
+        <div th:replace="/fragments/footer :: copy"></div>
+    </body>
+</html>

--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -107,7 +107,7 @@ digraph G {
                 <i>Fetched <span th:text="${{workflow.retrievedOn}}">01/12/16 at 21:00</span></i>
                 <span th:if="${workflow.roBundle == null}"> - Generating download link&hellip; [<a th:href="@{'/workflows/' + ${workflow.id}}" href="#">Refresh</a>]</span>
                 <span th:if="${workflow.roBundle != null}">
-                    - <a th:href="@{'/workflows/' + ${workflow.id} + '/download'}" href="#">Download as Research Object Bundle</a>
+                    - <a th:href="@{'/workflows/' + ${workflow.id} + '/download'}" href="#" download="bundle.zip">Download as Research Object Bundle</a>
                     <a href="http://www.researchobject.org/" rel="noopener" target="_blank">[?]</a>
                 </span>
             </p>

--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -105,6 +105,7 @@ digraph G {
                     <img id="githubLogo" src="../static/img/GitHub-Mark-32px.png" th:src="@{/img/GitHub-Mark-32px.png}" width="24" height="24" />
                 </a>
                 <i>Fetched <span th:text="${{workflow.retrievedOn}}">01/12/16 at 21:00</span></i>
+                <span th:if="${workflow.roBundle == null}"> - Generating download link&hellip; [<a th:href="@{'/workflows/' + ${workflow.id}}" href="#">Refresh</a>]</span>
                 <span th:if="${workflow.roBundle != null}">
                     - <a th:href="@{'/workflows/' + ${workflow.id} + '/download'}" href="#">Download as Research Object Bundle</a>
                     <a href="http://www.researchobject.org/" rel="noopener" target="_blank">[?]</a>

--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -105,6 +105,10 @@ digraph G {
                     <img id="githubLogo" src="../static/img/GitHub-Mark-32px.png" th:src="@{/img/GitHub-Mark-32px.png}" width="24" height="24" />
                 </a>
                 <i>Fetched <span th:text="${{workflow.retrievedOn}}">01/12/16 at 21:00</span></i>
+                <span th:if="${workflow.roBundle != null}">
+                    - <a th:href="@{'/workflows/' + ${workflow.id} + '/download'}" href="#">Download as Research Object Bundle</a>
+                    <a href="http://www.researchobject.org/" rel="noopener" target="_blank">[?]</a>
+                </span>
             </p>
             <p th:text="${workflow.doc}">Workflow Doc</p>
         </div>

--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -39,8 +39,8 @@
                 <h4 class="modal-title" id="dotGraphLabel">Workflow DOT Graph</h4>
             </div>
             <div class="modal-body">
-                <a id="download-link-gv" href="" download="workflow.gv"></a>
-                <button id="download-gv" class="btn btn-primary" type="button">Download as .gv File</button>
+                <a id="download-link-dot" href="" download="workflow.dot"></a>
+                <button id="download-dot" class="btn btn-primary" type="button">Download as .dot File</button>
 <textarea id="dot" class="form-control" rows="15" th:field="${workflow.dotGraph}">
 digraph G {
     graph [


### PR DESCRIPTION
Implements pages by database ID at /workflows/{id}

Adds configurable path for storage of Research Object Bundles in the properties

Adds download endpoint for Research Object Bundles at /workflows/{id}/download and adds the link to this to workflow pages

Changes downloads of graph source from .gv to .dot

Closes #18
Closes #19 
Closes #24