### PR TITLE
Fix for Github blog URL not being set causing NullPointerException

### DIFF
--- a/src/main/java/org/commonwl/viewer/domain/ROBundle.java
+++ b/src/main/java/org/commonwl/viewer/domain/ROBundle.java
@@ -84,7 +84,7 @@ public class ROBundle {
             // This tool supports putting your ORCID in the blog field of github as a URL
             // eg http://orcid.org/0000-0000-0000-0000
             String authorBlog = authorDetails.getBlog();
-            if (authorBlog.startsWith("http://orcid.org/")) {
+            if (authorBlog != null && authorBlog.startsWith("http://orcid.org/")) {
                 author.setOrcid(new URI(authorBlog));
             }
 


### PR DESCRIPTION
In RO bundle generation