### PR TITLE
Add extra properties to Research Object manifests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,14 @@
             <id>jitpack.io</id>
             <url>https://jitpack.io</url>
         </repository>
+        <repository>
+            <id>apache.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>http://repository.apache.org/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+        </repository>
     </repositories>
 
 	<dependencies>
@@ -72,7 +80,7 @@
         <dependency>
             <groupId>org.apache.taverna.language</groupId>
             <artifactId>taverna-robundle</artifactId>
-            <version>0.15.1-incubating</version>
+            <version>0.16.0-incubating-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.slf4j</groupId>
@@ -90,6 +98,5 @@
 			</plugin>
 		</plugins>
 	</build>
-
-
+    
 </project>

--- a/src/main/java/org/commonwl/viewer/domain/HashableAgent.java
+++ b/src/main/java/org/commonwl/viewer/domain/HashableAgent.java
@@ -1,0 +1,68 @@
+package org.commonwl.viewer.domain;
+
+import org.apache.taverna.robundle.manifest.Agent;
+
+import java.net.URI;
+
+/**
+ * An implementation of Agent with added HashCode and Equals methods
+ * for use in sets
+ */
+public class HashableAgent extends Agent {
+
+    private String name;
+    private URI orcid;
+    private URI uri;
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public URI getOrcid() {
+        return orcid;
+    }
+
+    @Override
+    public void setOrcid(URI orcid) {
+        this.orcid = orcid;
+    }
+
+    @Override
+    public URI getUri() {
+        return uri;
+    }
+
+    @Override
+    public void setUri(URI uri) {
+        this.uri = uri;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass() || super.getClass() != o.getClass()) return false;
+
+        HashableAgent that = (HashableAgent) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (orcid != null ? !orcid.equals(that.orcid) : that.orcid != null) return false;
+        return uri != null ? uri.equals(that.uri) : that.uri == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (orcid != null ? orcid.hashCode() : 0);
+        result = 31 * result + (uri != null ? uri.hashCode() : 0);
+        return result;
+    }
+
+}

--- a/src/main/java/org/commonwl/viewer/domain/ROBundle.java
+++ b/src/main/java/org/commonwl/viewer/domain/ROBundle.java
@@ -19,8 +19,6 @@
 
 package org.commonwl.viewer.domain;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.taverna.robundle.Bundle;
 import org.apache.taverna.robundle.Bundles;
@@ -29,10 +27,8 @@ import org.apache.taverna.robundle.manifest.Manifest;
 import org.apache.taverna.robundle.manifest.PathMetadata;
 import org.commonwl.viewer.services.GitHubService;
 import org.eclipse.egit.github.core.RepositoryContents;
-import org.eclipse.egit.github.core.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
 
 import java.io.IOException;
 import java.net.URI;
@@ -40,7 +36,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -56,6 +54,7 @@ public class ROBundle {
     private Bundle bundle;
     private GithubDetails githubInfo;
     private String commitSha;
+    private Set<HashableAgent> authors = new HashSet<HashableAgent>();
 
     // Pattern for extracting version from a cwl file
     private final String CWL_VERSION_REGEX = "cwlVersion:\\s*\"?(?:cwl:)?([^\\s\"]+)\"?";
@@ -85,25 +84,6 @@ public class ROBundle {
             cwlViewer.setUri(new URI(appURL));
             manifest.setCreatedBy(cwlViewer);
 
-            // Github author attribution
-            // TODO: way to add all the contributors somehow
-            // TODO: set the aggregates details according to the github information
-            User authorDetails = githubService.getUser(githubInfo.getOwner());
-
-            List<Agent> authorList = new ArrayList<>(1);
-            Agent author = new Agent(authorDetails.getName());
-            author.setUri(new URI(authorDetails.getHtmlUrl()));
-
-            // This tool supports putting your ORCID in the blog field of github as a URL
-            // eg http://orcid.org/0000-0000-0000-0000
-            String authorBlog = authorDetails.getBlog();
-            if (authorBlog != null && authorBlog.startsWith("http://orcid.org/")) {
-                author.setOrcid(new URI(authorBlog));
-            }
-
-            authorList.add(author);
-            manifest.setAuthoredBy(authorList);
-
             // Retrieval Info
             manifest.setRetrievedBy(cwlViewer);
             manifest.setRetrievedOn(manifest.getCreatedOn());
@@ -120,7 +100,10 @@ public class ROBundle {
 
         // Add the files from the Github repo to this workflow
         List<RepositoryContents> repoContents = githubService.getContents(githubInfo);
-        addFiles(repoContents, bundleFiles, manifest);
+        addFiles(repoContents, bundleFiles);
+
+        // Add combined authors
+        manifest.setAuthoredBy(new ArrayList<Agent>(authors));
     }
 
     /**
@@ -128,8 +111,7 @@ public class ROBundle {
      * @param repoContents The contents of the Github repository
      * @param path The path in the Research Object to add the files
      */
-    private void addFiles(List<RepositoryContents> repoContents, Path path,
-                          Manifest manifest) throws IOException {
+    private void addFiles(List<RepositoryContents> repoContents, Path path) throws IOException {
 
         // Loop through repo contents and add them
         for (RepositoryContents repoContent : repoContents) {
@@ -147,7 +129,7 @@ public class ROBundle {
                 Files.createDirectory(subdirPath);
 
                 // Add the files in the subdirectory to this new folder
-                addFiles(subdirectory, subdirPath, manifest);
+                addFiles(subdirectory, subdirPath);
 
                 // Otherwise this is a file so add to the bundle
             } else if (repoContent.getType().equals("file")) {
@@ -162,7 +144,7 @@ public class ROBundle {
                 Bundles.setStringValue(newFilePort, fileContent);
 
                 // Manifest aggregation
-                PathMetadata aggregation = manifest.getAggregation(newFilePort);
+                PathMetadata aggregation = bundle.getManifest().getAggregation(newFilePort);
 
                 try {
                     // Special handling for cwl files
@@ -177,6 +159,11 @@ public class ROBundle {
                             aggregation.setConformsTo(new URI("https://w3id.org/cwl/" + m.group(1)));
                         }
                     }
+
+                    // Add authors from github commits to the file
+                    Set<HashableAgent> fileAuthors = githubService.getContributors(githubFile, commitSha);
+                    authors.addAll(fileAuthors);
+                    aggregation.setAuthoredBy(new ArrayList<Agent>(fileAuthors));
 
                     // Set retrievedFrom information for this file in the manifest
                     aggregation.setRetrievedFrom(new URI("https://github.com/" + githubFile.getOwner() + "/" +


### PR DESCRIPTION
Addition of the following to the manifest:
* `conformsTo` for `.cwl` extension files pointing to the relevant version number of the spec at `https://w3id.org/cwl/`
* `retrievedFrom`, `retrievedBy` and `retrievedOn`
* Author details from Github commits using their name and Github URI

Note that support for ORCIDs in the 'blog' section of profiles has been removed as this would cause an extra API query for each user as well as the existing added overhead of a query for each commit

Closes #40