### PR TITLE
File size limits

### DIFF
--- a/src/main/java/org/commonwl/viewer/domain/CWLCollection.java
+++ b/src/main/java/org/commonwl/viewer/domain/CWLCollection.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.commonwl.viewer.services.DockerService;
 import org.eclipse.egit.github.core.RepositoryContents;
@@ -42,6 +43,8 @@ public class CWLCollection {
     private GitHubService githubService;
     private GithubDetails githubInfo;
     private String commitSha;
+
+    private int singleFileSizeLimit;
 
     // Maps of ID to associated JSON
     private Map<String, JsonNode> workflows = new HashMap<>();
@@ -90,10 +93,11 @@ public class CWLCollection {
      * @throws IOException Any API errors which may have occurred
      */
     public CWLCollection(GitHubService githubService, GithubDetails githubInfo,
-                         String commitSha) throws IOException {
+                         String commitSha, int singleFileSizeLimit) throws IOException {
         this.githubInfo = githubInfo;
         this.githubService = githubService;
         this.commitSha = commitSha;
+        this.singleFileSizeLimit = singleFileSizeLimit;
 
         // Add any CWL files from the Github repo to this collection
         List<RepositoryContents> repoContents = githubService.getContents(githubInfo);
@@ -129,19 +133,24 @@ public class CWLCollection {
 
                     // If this is a cwl file which needs to be parsed
                     if (extension.equals(CWL_EXTENSION)) {
+                        if (repoContent.getSize() <= singleFileSizeLimit) {
+                            // Get the content of this file from Github
+                            GithubDetails githubFile = new GithubDetails(githubInfo.getOwner(),
+                                    githubInfo.getRepoName(), githubInfo.getBranch(), repoContent.getPath());
+                            String fileContent = githubService.downloadFile(githubFile, commitSha);
 
-                        // Get the content of this file from Github
-                        GithubDetails githubFile = new GithubDetails(githubInfo.getOwner(),
-                                githubInfo.getRepoName(), githubInfo.getBranch(), repoContent.getPath());
-                        String fileContent = githubService.downloadFile(githubFile, commitSha);
+                            // Parse yaml to JsonNode
+                            Yaml reader = new Yaml();
+                            ObjectMapper mapper = new ObjectMapper();
+                            JsonNode cwlFile = mapper.valueToTree(reader.load(fileContent));
 
-                        // Parse yaml to JsonNode
-                        Yaml reader = new Yaml();
-                        ObjectMapper mapper = new ObjectMapper();
-                        JsonNode cwlFile = mapper.valueToTree(reader.load(fileContent));
-
-                        // Add document to those being considered
-                        addDoc(cwlFile, repoContent.getName());
+                            // Add document to those being considered
+                            addDoc(cwlFile, repoContent.getName());
+                        } else {
+                            throw new IOException("File '" + repoContent.getName() +  "' is over singleFileSizeLimit - " +
+                                    FileUtils.byteCountToDisplaySize(repoContent.getSize()) + "/" +
+                                    FileUtils.byteCountToDisplaySize(singleFileSizeLimit));
+                        }
                     }
                 }
 

--- a/src/main/java/org/commonwl/viewer/domain/CWLCollection.java
+++ b/src/main/java/org/commonwl/viewer/domain/CWLCollection.java
@@ -128,8 +128,13 @@ public class CWLCollection {
                 addDocs(subdirectory);
 
             } else if (repoContent.getType().equals(FILE)) {
-                // Keep track of total file size for limit
-                totalFileSize += repoContent.getSize();
+
+                // Keep track of total file size for limit - only track files which
+                // will be added to the RO bundle due to being small enough
+                if (repoContent.getSize() <= singleFileSizeLimit) {
+                    totalFileSize += repoContent.getSize();
+                }
+
                 if (totalFileSize <= totalFileSizeLimit) {
                     // Get the file extension
                     int eIndex = repoContent.getName().lastIndexOf('.') + 1;

--- a/src/main/java/org/commonwl/viewer/services/ROBundleFactory.java
+++ b/src/main/java/org/commonwl/viewer/services/ROBundleFactory.java
@@ -47,6 +47,7 @@ public class ROBundleFactory {
 
     private final String applicationName;
     private final String applicationURL;
+    private final int singleFileSizeLimit;
     private final Path storageLocation;
     private final WorkflowRepository workflowRepository;
 
@@ -54,11 +55,13 @@ public class ROBundleFactory {
     public ROBundleFactory(@Value("${applicationName}") String applicationName,
                            @Value("${applicationURL}") String applicationURL,
                            @Value("${graphvizStorage}") Path graphvizStorage,
+                           @Value("${singleFileSizeLimit}") int singleFileSizeLimit,
                            WorkflowRepository workflowRepository) {
         this.applicationName = applicationName;
         this.applicationURL = applicationURL;
         this.storageLocation = graphvizStorage;
         this.workflowRepository = workflowRepository;
+        this.singleFileSizeLimit = singleFileSizeLimit;
     }
 
     /**
@@ -75,7 +78,7 @@ public class ROBundleFactory {
 
         // Create a new Research Object Bundle with Github contents
         ROBundle bundle = new ROBundle(githubService, githubInfo, commitSha,
-                applicationName, applicationURL);
+                applicationName, applicationURL, singleFileSizeLimit);
 
         // Save the bundle to the storage location in properties
         Path bundleLocation = bundle.saveToFile(storageLocation);

--- a/src/main/java/org/commonwl/viewer/services/WorkflowService.java
+++ b/src/main/java/org/commonwl/viewer/services/WorkflowService.java
@@ -29,7 +29,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Calendar;
 import java.util.Date;
 
@@ -43,18 +42,21 @@ public class WorkflowService {
     private final ROBundleFactory ROBundleFactory;
     private final int cacheDays;
     private final String graphvizStorage;
+    private final int singleFileSizeLimit;
 
     @Autowired
     public WorkflowService(GitHubService githubService,
                            WorkflowRepository workflowRepository,
                            ROBundleFactory ROBundleFactory,
                            @Value("${cacheDays}") int cacheDays,
-                           @Value("${graphvizStorage}") String graphvizStorage) {
+                           @Value("${graphvizStorage}") String graphvizStorage,
+                           @Value("${singleFileSizeLimit}") int singleFileSizeLimit) {
         this.githubService = githubService;
         this.workflowRepository = workflowRepository;
         this.ROBundleFactory = ROBundleFactory;
         this.cacheDays = cacheDays;
         this.graphvizStorage = graphvizStorage;
+        this.singleFileSizeLimit = singleFileSizeLimit;
     }
 
     /**
@@ -69,7 +71,7 @@ public class WorkflowService {
             String latestCommit = githubService.getCommitSha(githubInfo);
 
             // Set up CWL utility to collect the documents
-            CWLCollection cwlFiles = new CWLCollection(githubService, githubInfo, latestCommit);
+            CWLCollection cwlFiles = new CWLCollection(githubService, githubInfo, latestCommit, singleFileSizeLimit);
 
             // Get the workflow model
             Workflow workflowModel = cwlFiles.getWorkflow();
@@ -170,24 +172,4 @@ public class WorkflowService {
             return false;
         }
     }
-
-    /*
-        // Check total file size
-        int totalFileSize = 0;
-        for (RepositoryContents repoContent : repoContents) {
-            totalFileSize += repoContent.getSize();
-        }
-        if (totalFileSize > totalFileSizeLimit) {
-            throw new IOException("Files within the Github directory can not be above "
-                                  + totalFileSizeLimit + "B in size");
-        }
-    */
-
-
-    /*
-        // Check file size before downloading
-        if (file.getSize() > singleFileSizeLimit) {
-            throw new IOException("Files within the Github directory can not be above " + singleFileSizeLimit + "B in size");
-        }
-    */
 }

--- a/src/main/java/org/commonwl/viewer/services/WorkflowService.java
+++ b/src/main/java/org/commonwl/viewer/services/WorkflowService.java
@@ -43,6 +43,7 @@ public class WorkflowService {
     private final int cacheDays;
     private final String graphvizStorage;
     private final int singleFileSizeLimit;
+    private final int totalFileSizeLimit;
 
     @Autowired
     public WorkflowService(GitHubService githubService,
@@ -50,13 +51,15 @@ public class WorkflowService {
                            ROBundleFactory ROBundleFactory,
                            @Value("${cacheDays}") int cacheDays,
                            @Value("${graphvizStorage}") String graphvizStorage,
-                           @Value("${singleFileSizeLimit}") int singleFileSizeLimit) {
+                           @Value("${singleFileSizeLimit}") int singleFileSizeLimit,
+                           @Value("${totalFileSizeLimit}") int totalFileSizeLimit) {
         this.githubService = githubService;
         this.workflowRepository = workflowRepository;
         this.ROBundleFactory = ROBundleFactory;
         this.cacheDays = cacheDays;
         this.graphvizStorage = graphvizStorage;
         this.singleFileSizeLimit = singleFileSizeLimit;
+        this.totalFileSizeLimit = totalFileSizeLimit;
     }
 
     /**
@@ -71,7 +74,8 @@ public class WorkflowService {
             String latestCommit = githubService.getCommitSha(githubInfo);
 
             // Set up CWL utility to collect the documents
-            CWLCollection cwlFiles = new CWLCollection(githubService, githubInfo, latestCommit, singleFileSizeLimit);
+            CWLCollection cwlFiles = new CWLCollection(githubService, githubInfo, latestCommit,
+                    singleFileSizeLimit, totalFileSizeLimit);
 
             // Get the workflow model
             Workflow workflowModel = cwlFiles.getWorkflow();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,7 +20,7 @@ cacheDays = 1
 # be externally linked in the Research Object Bundle
 singleFileSizeLimit = 5242880
 
-# File size limit for the contents of the entire repository path in bytes
+# File size limit for the contents of the research object bundle (not counting external links)
 totalFileSizeLimit = 1073741824
 
 #=======================

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,10 +16,10 @@ graphvizStorage = /tmp
 cacheDays = 1
 
 # File size limit for individual files in bytes
-singleFileSizeLimit = 5000000
+singleFileSizeLimit = 5242880
 
 # File size limit for the contents of the entire Research Object Bundle in bytes
-totalFileSizeLimit = 10000000
+totalFileSizeLimit = 1073741824
 
 #=======================
 # Github API settings

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,9 +16,11 @@ graphvizStorage = /tmp
 cacheDays = 1
 
 # File size limit for individual files in bytes
+# CWL files must be lower than this, but other files in the repo may be lower and in this case will
+# be externally linked in the Research Object Bundle
 singleFileSizeLimit = 5242880
 
-# File size limit for the contents of the entire Research Object Bundle in bytes
+# File size limit for the contents of the entire repository path in bytes
 totalFileSizeLimit = 1073741824
 
 #=======================


### PR DESCRIPTION
Single file size limit
* Mandatory for CWL files
* Optional for other files, they will be externally linked instead of downloaded if too large

Total file size limit is mandatory but only counts non-externally linked files to prevent a theoretical abusable exploit based on creating a repository containing many files of a size equal to `singleFileSizeLimit`

Closes #13