### PR TITLE
Optional: Git clones as async loading step

### DIFF
--- a/src/main/java/org/commonwl/view/workflow/QueuedWorkflow.java
+++ b/src/main/java/org/commonwl/view/workflow/QueuedWorkflow.java
@@ -20,7 +20,7 @@ public class QueuedWorkflow {
     private Workflow tempRepresentation;
 
     // Cwltool details
-    private CWLToolStatus cwltoolStatus = CWLToolStatus.RUNNING;
+    private CWLToolStatus cwltoolStatus = CWLToolStatus.DOWNLOADING;
     private String cwltoolVersion = "";
     private String message;
 

--- a/src/main/java/org/commonwl/view/workflow/QueuedWorkflow.java
+++ b/src/main/java/org/commonwl/view/workflow/QueuedWorkflow.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import org.commonwl.view.cwl.CWLToolStatus;
 import org.springframework.data.annotation.Id;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * A workflow pending completion of cwltool
  */
@@ -58,6 +61,18 @@ public class QueuedWorkflow {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public Map<String, String> getOverview() {
+        if (tempRepresentation != null && tempRepresentation.getLabel() != null) {
+            Map<String, String> overview = new HashMap<>();
+            overview.put("label", tempRepresentation.getLabel());
+            overview.put("inputs", Integer.toString(tempRepresentation.getInputs().size()));
+            overview.put("steps", Integer.toString(tempRepresentation.getSteps().size()));
+            overview.put("outputs", Integer.toString(tempRepresentation.getOutputs().size()));
+            return overview;
+        }
+        return null;
     }
 
 }

--- a/src/main/java/org/commonwl/view/workflow/QueuedWorkflow.java
+++ b/src/main/java/org/commonwl/view/workflow/QueuedWorkflow.java
@@ -64,7 +64,9 @@ public class QueuedWorkflow {
     }
 
     public Map<String, String> getOverview() {
-        if (tempRepresentation != null && tempRepresentation.getLabel() != null) {
+        if (tempRepresentation != null &&
+                tempRepresentation.getLabel() != null &&
+                tempRepresentation.getInputs() != null) {
             Map<String, String> overview = new HashMap<>();
             overview.put("label", tempRepresentation.getLabel());
             overview.put("inputs", Integer.toString(tempRepresentation.getInputs().size()));

--- a/src/main/java/org/commonwl/view/workflow/Workflow.java
+++ b/src/main/java/org/commonwl/view/workflow/Workflow.java
@@ -76,6 +76,8 @@ public class Workflow {
     // DOT graph of the contents
     private String visualisationDot;
 
+    public Workflow() {}
+
     public Workflow(String label, String doc, Map<String, CWLElement> inputs,
                     Map<String, CWLElement> outputs, Map<String, CWLStep> steps, String dockerLink) {
         this.label = label;
@@ -84,6 +86,10 @@ public class Workflow {
         this.outputs = outputs;
         this.steps = steps;
         this.dockerLink = dockerLink;
+    }
+
+    public Workflow(GitDetails gitDetails) {
+        this.retrievedFrom = gitDetails;
     }
 
     public String getID() { return id; }

--- a/src/main/java/org/commonwl/view/workflow/WorkflowController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowController.java
@@ -471,7 +471,7 @@ public class WorkflowController {
         if (queued != null) {
             // Retry creation if there has been an error in cwltool parsing
             if (queued.getCwltoolStatus() == CWLToolStatus.ERROR) {
-                workflowService.retryCwltool(queued);
+                workflowService.retryCreate(queued);
             }
             return new ModelAndView("loading", "queued", queued);
         } else {

--- a/src/main/resources/static/js/loading.js
+++ b/src/main/resources/static/js/loading.js
@@ -49,7 +49,13 @@ require(['jquery'],
         }
 
         function handleFail(error) {
-            $("#loadingHeader").html('Failed to parse ' + $("#workflowName").text() + ' with <a href="https://github.com/common-workflow-language/cwltool" rel="noopener" target="_blank">cwltool</a>');
+            if (currentStatus == 'DOWNLOADING') {
+                $("#loadingHeader").html('Failed to get the workflow from the Git repository');
+                $("#loadingError").text(error);
+            } else {
+                $("#loadingHeader").html('Failed to parse ' + $("#workflowName").text() + ' with <a href="https://github.com/common-workflow-language/cwltool" rel="noopener" target="_blank">cwltool</a>');
+                $("#errorMsg").text(error);
+            }
             $("#loadingOverview").html('<a id="cwllog" href="#">Show Details</a>');
             $("#loadingSpinner").fadeOut(function() {
                 $("#loadingFail").fadeIn();
@@ -57,7 +63,6 @@ require(['jquery'],
             $("#loadingWarning").html('<a class="btn btn-default" role="button" href="javascript:window.location.reload(true)">' +
                 '<span class="glyphicon glyphicon-refresh" aria-hidden="true"></span> Try Again' +
                 '</a>');
-            $("#errorMsg").text(error);
         }
 
         function retryWithDelay() {
@@ -73,13 +78,11 @@ require(['jquery'],
                 dataType: "json",
                 cache: false,
                 success: function(response) {
-                    console.log(response);
                     if (response.hasOwnProperty("label")) {
                         response.cwltoolStatus = "SUCCESS"
                     }
                     if (response.cwltoolStatus != currentStatus) {
-                        currentStatus = response.cwltoolStatus;
-                        switch (currentStatus) {
+                        switch (response.cwltoolStatus) {
                             case "RUNNING":
                                 $("#loadingHeader").html("Validating workflow " + response.overview.label + " with " +
                                     "<a href='https://github.com/common-workflow-language/cwltool' rel='noopener' " +
@@ -101,6 +104,7 @@ require(['jquery'],
                                 handleSuccess();
                                 break;
                         }
+                        currentStatus = response.cwltoolStatus;
                     } else {
                         retryWithDelay()
                     }

--- a/src/main/resources/static/js/loading.js
+++ b/src/main/resources/static/js/loading.js
@@ -32,6 +32,7 @@ requirejs.config({
  */
 require(['jquery'],
     function ($) {
+        var currentStatus = $("#currentStatus").text();
 
         function handleSuccess() {
             $("#loadingSpinner").hide();
@@ -59,22 +60,34 @@ require(['jquery'],
                 dataType: "json",
                 cache: false,
                 success: function(response) {
-                    if (response.cwltoolStatus == "RUNNING") {
+                    if (response.hasOwnProperty("label")) {
+                        response.cwltoolStatus = "SUCCESS"
+                    }
+                    if (response.cwltoolStatus != currentStatus) {
+                        currentStatus = response.cwltoolStatus;
+                        switch (currentStatus) {
+                            case "RUNNING":
+                                location.reload();
+                                break;
+                            case "ERROR":
+                                handleFail(response.message);
+                                break;
+                            case "SUCCESS":
+                                handleSuccess();
+                                break;
+                        }
+                    } else {
                         // Retry in 3 seconds
                         setTimeout(function () {
                             checkForDone();
-                        }, 3000);
-                    } else if (response.cwltoolStatus == "ERROR") {
-                        handleFail(response.message);
-                    } else {
-                        handleSuccess();
+                        }, 1000);
                     }
                 },
-                error: function(response) {
+                error: function() {
                     // Retry in 3 seconds
                     setTimeout(function () {
                         checkForDone();
-                    }, 3000);
+                    }, 1000);
                 }
             });
         }

--- a/src/main/resources/templates/fragments/error.html
+++ b/src/main/resources/templates/fragments/error.html
@@ -41,7 +41,7 @@
                     <p>
                         If this error was unexpected, you can help us by
                         <a href="https://github.com/common-workflow-language/cwlviewer/issues" rel="noopener" target="_blank">creating a Github issue</a> with details on how to reproduce it
-                        and/or <a href="https://gitter.im/common-workflow-language/common-workflow-language" rel="noopener" target="_blank">discussing it on Gitter</a>
+                        and/or <a href="https://gitter.im/common-workflow-language/cwlviewer" rel="noopener" target="_blank">discussing it on Gitter</a>
                     </p>
                 </div>
             </div>

--- a/src/main/resources/templates/loading.html
+++ b/src/main/resources/templates/loading.html
@@ -39,7 +39,7 @@
 <div id="currentStatus" class="hide" th:text="${queued.cwltoolStatus.name()}"></div>
 
 <div class="container" th:with="githubURLPart=${queued.tempRepresentation.retrievedFrom.getUrl().replace('https://', '')}">
-    <div class="row" th:if="${queued.cwltoolStatus.name() != 'DOWNLOADING'}">
+    <div class="row" th:if="${queued.cwltoolStatus.name() != 'DOWNLOADING' and queued.tempRepresentation.inputs != null}">
         <div class="col-md-12 text-center" role="main" id="main">
             <h2 id="loadingHeader">Validating workflow <span th:text="${queued.tempRepresentation.label}" id="workflowName">Workflow Name</span> with
                 <a href="https://github.com/common-workflow-language/cwltool" rel="noopener" target="_blank">cwltool</a>...</h2>
@@ -64,15 +64,15 @@
         </div>
     </div>
 
-    <div class="row" th:if="${queued.cwltoolStatus.name() == 'DOWNLOADING'}">
+    <div class="row" th:if="${queued.cwltoolStatus.name() == 'DOWNLOADING' or queued.tempRepresentation.inputs == null}">
         <div class="col-md-12 text-center" role="main" id="main">
             <h2 id="loadingHeader">Checking out Git repository...</h2>
             <p id="loadingOverview">
                 <span th:text="${queued.tempRepresentation.retrievedFrom.repoUrl}">https://github.com/owner/repo.git</span>
             </p>
             <div id="cwltooldetails" class="alert alert-danger">
-                <p><strong>Error:</strong> cwltool version <span th:text="${queued.cwltoolVersion}">versionhere</span> failed to run on this workflow:</p>
-                <pre id="errorMsg" class="text-left">Sample Error, tool failed initialisation</pre>
+                <p id="loadingError"><strong>Error:</strong> cwltool version <span th:text="${queued.cwltoolVersion}">versionhere</span> failed to run on this workflow:</p>
+                <pre id="errorMsg" class="text-left"></pre>
             </div>
             <div class="loadingWorkflowContainer">
                 <img id="loadingWorkflow" src="../static/img/gitlogo.png" th:src="@{'/img/gitlogo.png'}" />

--- a/src/main/resources/templates/loading.html
+++ b/src/main/resources/templates/loading.html
@@ -36,9 +36,10 @@
 <nav th:replace="fragments/header :: navbar"></nav>
 
 <div id="workflowID" class="hide" th:text="${queued.id}"></div>
+<div id="currentStatus" class="hide" th:text="${queued.cwltoolStatus.name()}"></div>
 
 <div class="container" th:with="githubURLPart=${queued.tempRepresentation.retrievedFrom.getUrl().replace('https://', '')}">
-    <div class="row">
+    <div class="row" th:if="${queued.cwltoolStatus.name() != 'DOWNLOADING'}">
         <div class="col-md-12 text-center" role="main" id="main">
             <h2 id="loadingHeader">Validating workflow <span th:text="${queued.tempRepresentation.label}" id="workflowName">Workflow Name</span> with
                 <a href="https://github.com/common-workflow-language/cwltool" rel="noopener" target="_blank">cwltool</a>...</h2>
@@ -60,6 +61,26 @@
                 <img id="loadingFail" alt="fail" src="../static/img/cross.svg" th:src="@{/img/cross.svg}" width="200" height="200" />
             </div>
             <p id="loadingWarning">This may take several minutes with very complex workflows</p>
+        </div>
+    </div>
+
+    <div class="row" th:if="${queued.cwltoolStatus.name() == 'DOWNLOADING'}">
+        <div class="col-md-12 text-center" role="main" id="main">
+            <h2 id="loadingHeader">Checking out Git repository...</h2>
+            <p id="loadingOverview">
+                <span th:text="${queued.tempRepresentation.retrievedFrom.repoUrl}">https://github.com/owner/repo.git</span>
+            </p>
+            <div id="cwltooldetails" class="alert alert-danger">
+                <p><strong>Error:</strong> cwltool version <span th:text="${queued.cwltoolVersion}">versionhere</span> failed to run on this workflow:</p>
+                <pre id="errorMsg" class="text-left">Sample Error, tool failed initialisation</pre>
+            </div>
+            <div class="loadingWorkflowContainer">
+                <img id="loadingWorkflow" src="../static/img/gitlogo.png" th:src="@{'/img/gitlogo.png'}" />
+                <img id="loadingSpinner" alt="loading" src="../static/img/loading.svg" th:src="@{/img/loading.svg}" width="200" height="200" />
+                <img id="loadingSuccess" alt="success" src="../static/img/tick.svg" th:src="@{/img/tick.svg}" width="200" height="200" />
+                <img id="loadingFail" alt="fail" src="../static/img/cross.svg" th:src="@{/img/cross.svg}" width="200" height="200" />
+            </div>
+            <p id="loadingWarning">This may take several minutes with very large repositories</p>
         </div>
     </div>
 </div>

--- a/src/test/java/org/commonwl/view/workflow/WorkflowServiceTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowServiceTest.java
@@ -19,7 +19,6 @@
 
 package org.commonwl.view.workflow;
 
-import org.commonwl.view.cwl.CWLService;
 import org.commonwl.view.cwl.CWLToolRunner;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.git.GitService;
@@ -72,9 +71,6 @@ public class WorkflowServiceTest {
         WorkflowRepository mockWorkflowRepo = Mockito.mock(WorkflowRepository.class);
         when(mockWorkflowRepo.findByRetrievedFrom(anyObject())).thenReturn(oldWorkflow);
 
-        CWLService mockCWLService = Mockito.mock(CWLService.class);
-        when(mockCWLService.parseWorkflowNative(anyObject())).thenReturn(updatedWorkflow);
-
         Repository mockRepo = Mockito.mock(Repository.class);
         when(mockRepo.getWorkTree()).thenReturn(new File("src/test/resources/cwl/make_to_cwl/dna.cwl"));
 
@@ -87,8 +83,7 @@ public class WorkflowServiceTest {
 
         // Create service under test with negative cache time (always create new workflow)
         WorkflowService testWorkflowService = new WorkflowService(
-                mockGitService, mockCWLService,
-                mockWorkflowRepo, Mockito.mock(QueuedWorkflowRepository.class),
+                mockGitService, mockWorkflowRepo, Mockito.mock(QueuedWorkflowRepository.class),
                 Mockito.mock(ROBundleFactory.class),
                 Mockito.mock(GraphVizService.class),
                 Mockito.mock(CWLToolRunner.class), -1);
@@ -124,7 +119,7 @@ public class WorkflowServiceTest {
 
         // Create service under test
         WorkflowService testWorkflowService = new WorkflowService(
-                Mockito.mock(GitService.class), Mockito.mock(CWLService.class),
+                Mockito.mock(GitService.class),
                 mockWorkflowRepo, Mockito.mock(QueuedWorkflowRepository.class),
                 Mockito.mock(ROBundleFactory.class),
                 Mockito.mock(GraphVizService.class),


### PR DESCRIPTION
This is an optional merge into the `generic-git` branch to make Git cloning asynchronous, to prevent a large page load time for the loading page itself due to cloning the repository. 

This does have the side effect that simple mistakes in inputs such as the wrong branch are redirected and have an error message shown on the loading page instead of back in the form, which is not as good of a user experience in this case.

[ ] - Solutions to this to be considered