### PR TITLE
Schema.org parsing for author information in RO manifest

### DIFF
--- a/src/main/java/org/commonwl/view/cwl/RDFService.java
+++ b/src/main/java/org/commonwl/view/cwl/RDFService.java
@@ -310,19 +310,19 @@ public class RDFService {
                 "SELECT ?email ?name ?orcid\n" +
                 "WHERE {\n" +
                 "  GRAPH ?graphName {" +
-                "    ?file s:creator ?creator .\n" +
+                "    ?file s:author|s:contributor|s:creator ?author .\n" +
                 "    {\n" +
                 "      ?creator rdf:type s:Person .\n" +
-                "      OPTIONAL { ?creator s:email ?email }\n" +
-                "      OPTIONAL { ?creator s:name ?name }\n" +
-                "      OPTIONAL { ?creator s:sameAs ?orcid }\n" +
+                "      OPTIONAL { ?author s:email ?email }\n" +
+                "      OPTIONAL { ?author s:name ?name }\n" +
+                "      OPTIONAL { ?author s:id|s:sameAs ?orcid }\n" +
                 "    } UNION {\n" +
-                "      ?creator rdf:type s:Organization .\n" +
-                "      ?creator s:department* ?dept .\n" +
+                "      ?author rdf:type s:Organization .\n" +
+                "      ?author s:department* ?dept .\n" +
                 "      ?dept s:member ?member\n" +
                 "      OPTIONAL { ?member s:email ?email }\n" +
                 "      OPTIONAL { ?member s:name ?name }\n" +
-                "      OPTIONAL { ?member s:sameAs ?orcid }\n" +
+                "      OPTIONAL { ?member s:id|s:sameAs ?orcid }\n" +
                 "    }\n" +
                 "    FILTER(regex(str(?orcid), \"^https?://orcid.org/\" ))\n" +
                 "    FILTER(regex(str(?file), ?wfFilter, \"i\" ))\n" +

--- a/src/main/java/org/commonwl/view/cwl/RDFService.java
+++ b/src/main/java/org/commonwl/view/cwl/RDFService.java
@@ -37,7 +37,8 @@ public class RDFService {
             "PREFIX sld: <https://w3id.org/cwl/salad#>\n" +
             "PREFIX Workflow: <https://w3id.org/cwl/cwl#Workflow/>\n" +
             "PREFIX DockerRequirement: <https://w3id.org/cwl/cwl#DockerRequirement/>\n" +
-            "PREFIX rdfs: <rdfs:>";
+            "PREFIX rdfs: <rdfs:>\n" +
+            "PREFIX s: <http://schema.org/>";
 
     private String rdfService;
 
@@ -103,6 +104,7 @@ public class RDFService {
 
     /**
      * Get the label and doc strings for a workflow resource
+     * @param path The path within the Git repository to the workflow
      * @param workflowURI The URI of the workflow
      * @return Result set with label and doc strings
      */
@@ -112,6 +114,7 @@ public class RDFService {
                 "SELECT ?label ?doc\n" +
                 "WHERE {\n" +
                 "  GRAPH ?graphName {" +
+                "    ?wf rdf:type ?type .\n" +
                 "    OPTIONAL { ?wf sld:label|rdfs:label ?label }\n" +
                 "    OPTIONAL { ?wf sld:doc|rdfs:comment ?doc }\n" +
                 "    FILTER(regex(str(?wf), ?wfFilter, \"i\" ))" +
@@ -148,6 +151,7 @@ public class RDFService {
 
     /**
      * Get the inputs for the workflow in the model
+     * @param path The path within the Git repository to the workflow
      * @param workflowURI URI of the workflow
      * @return The result set of inputs
      */
@@ -173,6 +177,7 @@ public class RDFService {
 
     /**
      * Get the outputs for the workflow in the model
+     * @param path The path within the Git repository to the workflow
      * @param workflowURI URI of the workflow
      * @return The result set of outputs
      */
@@ -198,6 +203,7 @@ public class RDFService {
 
     /**
      * Get the steps for the workflow in the model
+     * @param path The path within the Git repository to the workflow
      * @param workflowURI URI of the workflow
      * @return The result set of steps
      */
@@ -270,6 +276,7 @@ public class RDFService {
 
     /**
      * Gets the docker requirement and pull link for a workflow
+     * @param path The path within the Git repository to the workflow
      * @param workflowURI URI of the workflow
      * @return Result set of docker hint and pull link
      */
@@ -289,6 +296,41 @@ public class RDFService {
         dockerQuery.setLiteral("wfFilter", path + "$");
         dockerQuery.setIri("graphName", rdfService + workflowURI);
         return runQuery(dockerQuery);
+    }
+
+    /**
+     * Get authors from schema.org creator fields for a file
+     * @param path The path within the Git repository to the file
+     * @param fileUri URI of the file
+     * @return The result set of step links
+     */
+    public ResultSet getAuthors(String path, String fileUri) {
+        ParameterizedSparqlString linkQuery = new ParameterizedSparqlString();
+        linkQuery.setCommandText(queryCtx +
+                "SELECT ?email ?name ?orcid\n" +
+                "WHERE {\n" +
+                "  GRAPH ?graphName {" +
+                "    ?file s:creator ?creator .\n" +
+                "    {\n" +
+                "      ?creator rdf:type s:Person .\n" +
+                "      OPTIONAL { ?creator s:email ?email }\n" +
+                "      OPTIONAL { ?creator s:name ?name }\n" +
+                "      OPTIONAL { ?creator s:sameAs ?orcid }\n" +
+                "    } UNION {\n" +
+                "      ?creator rdf:type s:Organization .\n" +
+                "      ?creator s:department* ?dept .\n" +
+                "      ?dept s:member ?member\n" +
+                "      OPTIONAL { ?member s:email ?email }\n" +
+                "      OPTIONAL { ?member s:name ?name }\n" +
+                "      OPTIONAL { ?member s:sameAs ?orcid }\n" +
+                "    }\n" +
+                "    FILTER(regex(str(?orcid), \"^https?://orcid.org/\" ))\n" +
+                "    FILTER(regex(str(?file), ?wfFilter, \"i\" ))\n" +
+                "  }" +
+                "}");
+        linkQuery.setLiteral("wfFilter", path + "$");
+        linkQuery.setIri("graphName", rdfService + fileUri);
+        return runQuery(linkQuery);
     }
 
     /**

--- a/src/main/java/org/commonwl/view/git/GitDetails.java
+++ b/src/main/java/org/commonwl/view/git/GitDetails.java
@@ -47,11 +47,7 @@ public class GitDetails implements Serializable {
         }
 
         // Default to root path
-        if (path == null || path.isEmpty()) {
-            this.path = "/";
-        } else {
-            this.path = path;
-        }
+        setPath(path);
     }
 
 
@@ -76,7 +72,13 @@ public class GitDetails implements Serializable {
     }
 
     public void setPath(String path) {
-        this.path = path;
+        if (path == null || path.isEmpty()) {
+            this.path = "/";
+        } else if (path.startsWith("/") && path.length() > 1) {
+            this.path = path.substring(1);
+        } else {
+            this.path = path;
+        }
     }
 
     /**

--- a/src/main/java/org/commonwl/view/researchobject/HashableAgent.java
+++ b/src/main/java/org/commonwl/view/researchobject/HashableAgent.java
@@ -78,18 +78,26 @@ public class HashableAgent extends Agent {
 
         HashableAgent that = (HashableAgent) o;
 
-        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        // ORCID is a unique identifier so if matches, the objects are equal
+        if (orcid != null && orcid.equals(that.orcid)) return true;
+
+        // If no ORCID is present but email is the name, the objects are equal
+        if (orcid == null && uri != null && uri.equals(that.uri)) return true;
+
+        // Default to checking all parameters
         if (orcid != null ? !orcid.equals(that.orcid) : that.orcid != null) return false;
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
         return uri != null ? uri.equals(that.uri) : that.uri == null;
 
     }
 
+    /**
+     * ORCID is used as hashcode to fall back to comparison if missing
+     * @return The hash code for this object
+     */
     @Override
     public int hashCode() {
-        int result = name != null ? name.hashCode() : 0;
-        result = 31 * result + (orcid != null ? orcid.hashCode() : 0);
-        result = 31 * result + (uri != null ? uri.hashCode() : 0);
-        return result;
+        return orcid != null ? orcid.hashCode() : 0;
     }
 
 }

--- a/src/main/java/org/commonwl/view/researchobject/ROBundleService.java
+++ b/src/main/java/org/commonwl/view/researchobject/ROBundleService.java
@@ -303,7 +303,7 @@ public class ROBundleService {
                                     gitPath.toString());
 
                             if (cwl) {
-                                // Attempt to get authors from cwl description
+                                // Attempt to get authors from cwl description - takes priority
                                 ResultSet descAuthors = rdfService.getAuthors(bundlePath
                                         .resolve(file.getName()).toString().substring(10), url);
                                 if (descAuthors.hasNext()) {
@@ -318,6 +318,7 @@ public class ROBundleService {
                                     if (authorSoln.contains("orcid")) {
                                         newAuthor.setOrcid(new URI(authorSoln.get("orcid").toString()));
                                     }
+                                    fileAuthors.remove(newAuthor);
                                     fileAuthors.add(newAuthor);
                                 }
                             }

--- a/src/main/java/org/commonwl/view/workflow/WorkflowRepository.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowRepository.java
@@ -50,5 +50,5 @@ public interface WorkflowRepository extends PagingAndSortingRepository<Workflow,
      * @param doc The string to search for in the doc
      * @param pageable The details of the page to be retrieved
      */
-    Page<Workflow> findByLabelContainingOrDocContaining(String label, String doc, Pageable pageable);
+    Page<Workflow> findByLabelContainingOrDocContainingIgnoreCase(String label, String doc, Pageable pageable);
 }

--- a/src/main/java/org/commonwl/view/workflow/WorkflowService.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowService.java
@@ -93,7 +93,7 @@ public class WorkflowService {
      * @return The resulting page of the workflow entries
      */
     public Page<Workflow> searchPageOfWorkflows(String searchString, Pageable pageable) {
-        return workflowRepository.findByLabelContainingOrDocContaining(searchString, searchString, pageable);
+        return workflowRepository.findByLabelContainingOrDocContainingIgnoreCase(searchString, searchString, pageable);
     }
 
     /**

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -136,16 +136,15 @@
             <h2>Attribution</h2>
             <p class="recommendation">Include attribution information in your workflow and tool descriptions</p>
             <p class="recommendation_more">
-                For example, to attribute a person as the creator of a workflow or tool with name, email and
+                For example, to attribute a person as the author of a workflow or tool with name, email and
                 ORCID information, include the following statements at the top level:<br />
 <pre>
 $namespaces: { s: "http://schema.org/" }
-s:creator:
+s:author:
 - class: s:Person
   s:name: Mark Robinson
   s:email: mailto:mark@example.com
-  s:sameAs:
-  - id: http://orcid.org/0000-0002-8184-7507
+  s:id: http://orcid.org/0000-0002-8184-7507
 </pre>
                 For attributing organisations, see <a href="https://github.com/Barski-lab/ga4gh_challenge/blob/9de2f0c29ae09e31a434d6c5c969a5e3b2dbf535/biowardrobe_chipseq_se.cwl#L387">this workflow</a>
                 as an example
@@ -155,7 +154,7 @@ s:creator:
             be uniquely identified from other researchers</p>
             <p class="use">CWLViewer parses attribution information for inclusion in the Research Object Manifest from
             both the Git commit logs and from the CWL descriptions themselves when expressed in the
-            <a href="http://schema.org/creator">http://schema.org/creator</a> format as above</p>
+            <a href="http://schema.org/author">http://schema.org/author</a> format as above</p>
 
             <h2>Licensing</h2>
             <p class="recommendation">Include a <a href="https://opensource.org/licenses">OSI approved open source license</a>

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -147,6 +147,8 @@ s:creator:
   s:sameAs:
   - id: http://orcid.org/0000-0002-8184-7507
 </pre>
+                For attributing organisations, see <a href="https://github.com/Barski-lab/ga4gh_challenge/blob/9de2f0c29ae09e31a434d6c5c969a5e3b2dbf535/biowardrobe_chipseq_se.cwl#L387">this workflow</a>
+                as an example
             </p>
             <p class="why">Attribution information allows your workflows and tooling to be used by others while
             recognising your contributions. The inclusion of an <a href="https://orcid.org/">ORCID</a> allows you to

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -44,7 +44,7 @@
                 understanding and discovery as well as encouraging best practices when writing workflows and their
                 tooling.</p>
 
-            <p>Cite as: <code><a href="https://doi.org/10.5281/zenodo.823534">10.5281/zenodo.823534</a></code></p>
+            <p>Cite as: <code><a href="https://doi.org/10.7490/f1000research.1114375.1">10.7490/f1000research.1114375.1</a></code></p>
 
             <p>A <a href="https://doi.org/10.5281/zenodo.823535">Technical Report for this project can be viewed here</a>.</p>
 
@@ -133,16 +133,38 @@
             <p class="use">Subworkflows are simplified in the visualisations and are linked as a different workflow in the
             <code>Step</code> tables on each workflow page</p>
 
+            <h2>Attribution</h2>
+            <p class="recommendation">Include attribution information in your workflow and tool descriptions</p>
+            <p class="recommendation_more">
+                For example, to attribute a person as the creator of a workflow or tool with name, email and
+                ORCID information, include the following statements at the top level:<br />
+<pre>
+$namespaces: { s: "http://schema.org/" }
+s:creator:
+- class: s:Person
+  s:name: Mark Robinson
+  s:email: mailto:mark@example.com
+  s:sameAs:
+  - id: http://orcid.org/0000-0002-8184-7507
+</pre>
+            </p>
+            <p class="why">Attribution information allows your workflows and tooling to be used by others while
+            recognising your contributions. The inclusion of an <a href="https://orcid.org/">ORCID</a> allows you to
+            be uniquely identified from other researchers</p>
+            <p class="use">CWLViewer parses attribution information for inclusion in the Research Object Manifest from
+            both the Git commit logs and from the CWL descriptions themselves when expressed in the
+            <a href="http://schema.org/creator">http://schema.org/creator</a> format as above</p>
+
             <h2>Licensing</h2>
             <p class="recommendation">Include a <a href="https://opensource.org/licenses">OSI approved open source license</a>
             in your workflow and tool descriptions</p>
             <p class="recommendation_more">
                 For example, the following two statements at the top level of a workflow or tool description licenses it
                 under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache V2.0 License</a>:<br />
-                <code>
-                    $namespaces: { s: "http://schema.org/" }<br />
-                    s:license: "https://www.apache.org/licenses/LICENSE-2.0"
-                </code>
+<pre>
+$namespaces: { s: "http://schema.org/" }
+s:license: "https://www.apache.org/licenses/LICENSE-2.0"
+</pre>
             </p>
             <p class="why">A permissive open source license allows others to remix and use your tooling and workflows
             to prevent the community from repeating development effort, allowing everyone to benefit</p>

--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -125,7 +125,6 @@ digraph G {
     <div class="row">
         <div class="col-md-12" role="main" id="main">
             <h2>Workflow: <span th:text="${workflow.label}">Workflow Name</span></h2>
-            <p th:text="${workflow.doc}">Workflow Doc</p>
         </div>
         <div class="col-md-6">
             <a th:href="@{${workflow.retrievedFrom.getUrl()}}" href="#" rel="noopener" target="_blank" style="text-decoration:none;">
@@ -142,6 +141,9 @@ digraph G {
         </div>
         <div class="col-md-6 text-right">
             <img class="verification_icon" src="../static/img/tick.svg" th:src="@{/img/tick.svg}" width="20" height="22" /> Verified with cwltool version <span th:text="${workflow.cwltoolVersion}">1.0.20170622090721</span>
+        </div>
+        <div class="col-md-12" style="margin-top:5px;" th:if="${workflow.doc != null}">
+            <p th:text="${workflow.doc}">Workflow Doc</p>
         </div>
     </div>
     <div class="row">

--- a/src/test/java/org/commonwl/view/researchobject/HashableAgentTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/HashableAgentTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.commonwl.view.researchobject;
+
+import org.junit.Test;
+
+import java.net.URI;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class HashableAgentTest {
+
+    /**
+     * If the ORCID of two agents is the same, they are the same person
+     * regardless of other information
+     */
+    @Test
+    public void orcidsMakeAgentsEqual() throws Exception {
+
+        HashableAgent firstOrcid = new HashableAgent("Mark Robindsason",
+                new URI("http://orcid.org/0000-0002-8184-7507"),
+                new URI("mark@example.org"));
+
+        HashableAgent secondOrcid = new HashableAgent("Mark Robinson",
+                new URI("http://orcid.org/0000-0002-8184-7507"),
+                new URI("mark@example.com"));
+
+        Set<HashableAgent> testSet = new HashSet<>();
+        testSet.add(firstOrcid);
+        testSet.remove(secondOrcid);
+        testSet.add(secondOrcid);
+
+        assertEquals(1, testSet.size());
+        HashableAgent fromSet = testSet.iterator().next();
+        assertEquals("Mark Robinson", fromSet.getName());
+        assertEquals(new URI("mark@example.com"), fromSet.getUri());
+        assertEquals(new URI("http://orcid.org/0000-0002-8184-7507"), fromSet.getOrcid());
+
+    }
+
+    /**
+     * When no ORCID is present but emails are the same, the agents are
+     * the same person regardless of name
+     */
+    @Test
+    public void noOrcidEmailSameMakesAgentsEqual() throws Exception {
+
+        HashableAgent firstEmail = new HashableAgent("Mark Robindsason",
+                null,
+                new URI("mark@example.com"));
+
+        HashableAgent secondEmail = new HashableAgent("Mark Robinson",
+                null,
+                new URI("mark@example.com"));
+
+        Set<HashableAgent> testSet = new HashSet<>();
+        testSet.add(firstEmail);
+        testSet.remove(secondEmail);
+        testSet.add(secondEmail);
+
+        assertEquals(1, testSet.size());
+        HashableAgent fromSet = testSet.iterator().next();
+        assertEquals("Mark Robinson", fromSet.getName());
+        assertEquals(new URI("mark@example.com"), fromSet.getUri());
+        assertNull(fromSet.getOrcid());
+
+    }
+}

--- a/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
@@ -25,6 +25,7 @@ import org.apache.taverna.robundle.manifest.Manifest;
 import org.apache.taverna.robundle.manifest.PathAnnotation;
 import org.apache.taverna.robundle.manifest.PathMetadata;
 import org.commonwl.view.cwl.CWLTool;
+import org.commonwl.view.cwl.RDFService;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.git.GitService;
 import org.commonwl.view.graphviz.GraphVizService;
@@ -110,7 +111,7 @@ public class ROBundleServiceTest {
         // Create new RO bundle
         ROBundleService bundleService = new ROBundleService(roBundleFolder.getRoot().toPath(),
                 "CWL Viewer", "https://view.commonwl.org", 5242880,
-                mockGraphvizService, mockGitService, mockCwlTool);
+                mockGraphvizService, mockGitService, Mockito.mock(RDFService.class), mockCwlTool);
         Bundle bundle = bundleService.createBundle(lobSTRv1, lobSTRv1RODetails);
         Path bundleRoot = bundle.getRoot().resolve("workflow");
 
@@ -207,7 +208,7 @@ public class ROBundleServiceTest {
         // Create new RO bundle
         ROBundleService bundleService = new ROBundleService(roBundleFolder.getRoot().toPath(),
                 "CWL Viewer", "https://view.commonwl.org", 0, mockGraphvizService,
-                mockGitService, mockCwlTool);
+                mockGitService, Mockito.mock(RDFService.class), mockCwlTool);
         Bundle bundle = bundleService.createBundle(lobSTRv1, lobSTRv1RODetails);
 
         Manifest manifest = bundle.getManifest();

--- a/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
@@ -19,6 +19,7 @@
 
 package org.commonwl.view.researchobject;
 
+import org.apache.jena.query.ResultSet;
 import org.apache.taverna.robundle.Bundle;
 import org.apache.taverna.robundle.Bundles;
 import org.apache.taverna.robundle.manifest.Manifest;
@@ -97,6 +98,12 @@ public class ROBundleServiceTest {
         when(mockCwlTool.getRDF(anyString()))
                 .thenReturn("@prefix cwl: <https://w3id.org/cwl/cwl#> .");
 
+        // Mock RDF Service
+        ResultSet emptyResult = Mockito.mock(ResultSet.class);
+        when(emptyResult.hasNext()).thenReturn(false);
+        RDFService mockRdfService = Mockito.mock(RDFService.class);
+        when(mockRdfService.getAuthors(anyString(), anyString())).thenReturn(emptyResult);
+
         // Workflow details
         GitDetails lobSTRv1Details = new GitDetails("https://github.com/common-workflow-language/workflows.git",
                 "933bf2a1a1cce32d88f88f136275535da9df0954", "workflows/lobSTR/lobSTR-workflow.cwl");
@@ -111,7 +118,7 @@ public class ROBundleServiceTest {
         // Create new RO bundle
         ROBundleService bundleService = new ROBundleService(roBundleFolder.getRoot().toPath(),
                 "CWL Viewer", "https://view.commonwl.org", 5242880,
-                mockGraphvizService, mockGitService, Mockito.mock(RDFService.class), mockCwlTool);
+                mockGraphvizService, mockGitService, mockRdfService, mockCwlTool);
         Bundle bundle = bundleService.createBundle(lobSTRv1, lobSTRv1RODetails);
         Path bundleRoot = bundle.getRoot().resolve("workflow");
 
@@ -194,6 +201,12 @@ public class ROBundleServiceTest {
         when(mockCwlTool.getRDF(anyString()))
                 .thenReturn("@prefix cwl: <https://w3id.org/cwl/cwl#> .");
 
+        // Mock RDF Service
+        ResultSet emptyResult = Mockito.mock(ResultSet.class);
+        when(emptyResult.hasNext()).thenReturn(false);
+        RDFService mockRdfService = Mockito.mock(RDFService.class);
+        when(mockRdfService.getAuthors(anyString(), anyString())).thenReturn(emptyResult);
+
         // Workflow details
         GitDetails lobSTRv1Details = new GitDetails("https://github.com/common-workflow-language/workflows.git",
                 "933bf2a1a1cce32d88f88f136275535da9df0954", "workflows/lobSTR/lobSTR-workflow.cwl");
@@ -208,7 +221,7 @@ public class ROBundleServiceTest {
         // Create new RO bundle
         ROBundleService bundleService = new ROBundleService(roBundleFolder.getRoot().toPath(),
                 "CWL Viewer", "https://view.commonwl.org", 0, mockGraphvizService,
-                mockGitService, Mockito.mock(RDFService.class), mockCwlTool);
+                mockGitService, mockRdfService, mockCwlTool);
         Bundle bundle = bundleService.createBundle(lobSTRv1, lobSTRv1RODetails);
 
         Manifest manifest = bundle.getManifest();


### PR DESCRIPTION
Use a combination of the `git log` output and http://schema.org/creator (both person and organiser->department*->member) markup from workflow and tool descriptions to generate the Research Object Bundle Manifest

Remaining tasks:
- [X] Use parsing of CWL RDF to add authors to RO Bundles
- [X] Add section to CWL Best Practices for attribution in http://schema.org/creator format 
- [x] Use ORCID as priority identifier followed by email. Discard git log entries if there is a corresponding email in the cwl description for the file
- [x] Tests for attribution and priority

Closes #130 