### PR TITLE
Fix for the image in twitter meta tags

### DIFF
--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -26,7 +26,7 @@
     <meta name="twitter:site" content="@commonwl" />
     <meta name="twitter:title" th:content="${'CWL Workflow: ' + workflow.label}" />
     <meta name="twitter:description" th:if="${workflow.doc != null}" th:content="${workflow.doc}" />
-    <meta name="twitter:image" th:content="${appURL + '/workflows/' + workflow.id + '/graph/png'}" />
+    <meta name="twitter:image" th:content="@{${workflow.getVisualisationPng()}}" />
     <title th:text="${workflow.label + ' - Common Workflow Language Viewer'}">Common Workflow Language Viewer</title>
     <link rel="stylesheet" th:href="@{/bower_components/bootstrap/dist/css/bootstrap.min.css}" href="../static/bower_components/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" type="text/css" th:href="@{/css/main-20170616.css}" href="../static/css/main-20170616.css" />


### PR DESCRIPTION
Was using the old URL format eg https://view.commonwl.org/workflows/598dc03d5d7156000181b00a/graph/png