### PR TITLE
Ensure asynchronous cwltool is on same git checkout

### DIFF
--- a/src/main/java/org/commonwl/view/git/GitService.java
+++ b/src/main/java/org/commonwl/view/git/GitService.java
@@ -19,6 +19,16 @@
 
 package org.commonwl.view.git;
 
+import static org.apache.jena.ext.com.google.common.io.Files.createTempDir;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.commonwl.view.researchobject.HashableAgent;
 import org.eclipse.jgit.api.Git;
@@ -32,16 +42,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.HashSet;
-import java.util.Set;
-
-import static org.apache.jena.ext.com.google.common.io.Files.createTempDir;
 
 /**
  * Handles Git related functionality
@@ -82,7 +82,6 @@ public class GitService {
                     // Check if folder already exists
                     Path repoDir = gitStorage.resolve(baseName);
                     if (Files.isReadable(repoDir) && Files.isDirectory(repoDir)) {
-                        repo = Git.open(repoDir.toFile());
                         repo.fetch().call();
                     } else {
                         // Create a folder and clone repository into it


### PR DESCRIPTION
... by acquiring its own semaphore within the async job and getting
the git repository again.

Note that this will mean an uncessary duplicate "fetch" - however
this also mean that the async "retryCwltool" works as intended
by pulling the branch again.