### PR TITLE
Expose Location header in CORS #189

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ $ mvn spring-boot:run
 
 Alternatively, you can run the application from your IDE as a simple Java application by importing the Maven project.
 
+You need to install [Graphviz](http://www.graphviz.org/) for all unit tests to pass.
+
 You can create an executable JAR file by using:
 
     mvn clean install

--- a/src/main/java/org/commonwl/view/WebConfig.java
+++ b/src/main/java/org/commonwl/view/WebConfig.java
@@ -68,6 +68,6 @@ public class WebConfig extends WebMvcConfigurerAdapter {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-	registry.addMapping("/**");  // .setMaxAge(Long.MAX_VALUE)
+	registry.addMapping("/**").exposedHeaders("Location");  // .setMaxAge(Long.MAX_VALUE)
     }
 }


### PR DESCRIPTION
## Description
For CORS requests, set `Access-Control-Expose-Headers: Location`.

## Motivation and Context
We want to display an SVG generated by view.commonwl.org in Dockstore.org. When we do a POST to /workflows, the POST can return a 202, with the location header specifying the queue. In order to check the status of the queue, we need access to the location header, which is not exposed by default in CORS.

Fixes #189 

## How Has This Been Tested?

I ran cwlviewer locally by running `docker-compose`. The fix was manually verified by invoking the endpoint with JavaScript code in a browser app. I was able to see the location header in my JavaScript code, which I hadn't been able to see before. In addition, in the Chrome debug tools, I saw the `Access-Control-Expose-Headers: Location` header in the response.

I did not add any new tests, but existing tests continue to pass.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
