### PR TITLE
Support for Git tags #191

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,12 @@
             <artifactId>org.eclipse.jgit</artifactId>
             <version>4.8.0.201706111038-r</version>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/org/commonwl/view/git/GitService.java
+++ b/src/main/java/org/commonwl/view/git/GitService.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -85,22 +86,12 @@ public class GitService {
             } else {
                 // Create a folder and clone repository into it
                 Files.createDirectory(repoDir);
-                repo = Git.cloneRepository()
-                        .setCloneSubmodules(cloneSubmodules)
-                        .setURI(gitDetails.getRepoUrl())
-                        .setDirectory(repoDir.toFile())
-                        .setCloneAllBranches(true)
-                        .call();
+                repo = cloneRepo(gitDetails.getRepoUrl(), repoDir.toFile());
             }
         } else {
             // Another thread is already using the existing folder
             // Must create another temporary one
-            repo = Git.cloneRepository()
-                    .setCloneSubmodules(cloneSubmodules)
-                    .setURI(gitDetails.getRepoUrl())
-                    .setDirectory(createTempDir())
-                    .setCloneAllBranches(true)
-                    .call();
+            repo = cloneRepo(gitDetails.getRepoUrl(), createTempDir());
         }
 
         // Checkout the specific branch or commit ID
@@ -206,4 +197,19 @@ public class GitService {
         }
     }
 
+    /**
+     * Clones a Git repository
+     * @param repoUrl the url of the Git repository
+     * @param directory the directory to clone the repo into
+     * @return a Git instance
+     * @throws GitAPIException if any error occurs cloning the repo
+     */
+    protected Git cloneRepo(String repoUrl, File directory) throws GitAPIException {
+        return Git.cloneRepository()
+                .setCloneSubmodules(cloneSubmodules)
+                .setURI(repoUrl)
+                .setDirectory(directory)
+                .setCloneAllBranches(true)
+                .call();
+    }
 }

--- a/src/test/java/org/commonwl/view/git/GitServiceTest.java
+++ b/src/test/java/org/commonwl/view/git/GitServiceTest.java
@@ -19,11 +19,50 @@
 
 package org.commonwl.view.git;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.eclipse.jgit.api.CheckoutCommand;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.api.errors.RefNotFoundException;
+import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 public class GitServiceTest {
+
+    private final RefNotFoundException branchNotFoundException = new RefNotFoundException("Branch not found");
+    private final RefNotFoundException tagNotFoundException = new RefNotFoundException("Tag not found");
+
+    private GitService spyGitService;
+    private Git mockGit;
+    private CheckoutCommand mockGoodCheckoutCommand;
+    private CheckoutCommand mockBranchNotFoundCommand;
+    private CheckoutCommand mockTagNotFoundCommand;
+    private CheckoutCommand mockCheckoutCommand;
+
+    @Before
+    public void setup() throws GitAPIException {
+        GitService gitService = new GitService(null, false);
+        this.spyGitService = spy(gitService);
+        this.mockGit = mock(Git.class);
+        this.mockGoodCheckoutCommand = mock(CheckoutCommand.class);
+        this.mockBranchNotFoundCommand = mock(CheckoutCommand.class);
+        this.mockTagNotFoundCommand = mock(CheckoutCommand.class);
+        this.mockCheckoutCommand = mock(CheckoutCommand.class);
+        when(this.mockGit.checkout()).thenReturn(this.mockCheckoutCommand);
+        when(this.mockBranchNotFoundCommand.call()).thenThrow(branchNotFoundException);
+        when(this.mockTagNotFoundCommand.call()).thenThrow(tagNotFoundException);
+    }
 
     @Test
     public void transferPathToBranch() throws Exception {
@@ -38,5 +77,36 @@ public class GitServiceTest {
         GitDetails step2 = gitService.transferPathToBranch(step1);
         assertEquals("branchpart1/branchpart2/branchpart3", step2.getBranch());
         assertEquals("workflowInRoot.cwl", step2.getPath());
+    }
+
+    @Test
+    public void checksOutTag() throws Exception {
+        when(mockCheckoutCommand.setName("refs/remotes/origin/mytag")).thenReturn(this.mockBranchNotFoundCommand);
+        when(mockCheckoutCommand.setName("mytag")).thenReturn(this.mockGoodCheckoutCommand);
+        doReturn(this.mockGit).when(this.spyGitService).cloneRepo(Mockito.any(String.class), Mockito.any(File.class));
+        assertNotNull(this.spyGitService.getRepository(new GitDetails(null, "mytag", "foo"), false));
+    }
+
+    @Test
+    public void checksOutBranch() throws GitAPIException, IOException {
+        when(mockCheckoutCommand.setName("refs/remotes/origin/mybranch")).thenReturn(this.mockGoodCheckoutCommand);
+        when(mockCheckoutCommand.setName("mytag")).thenReturn(this.mockTagNotFoundCommand);
+        doReturn(this.mockGit).when(this.spyGitService).cloneRepo(Mockito.any(String.class), Mockito.any(File.class));
+        assertNotNull(this.spyGitService.getRepository(new GitDetails(null, "mybranch", "foo"), false));
+    }
+
+    @Test()
+    public void throwsFirstExceptionIfTagAndBranchFail() throws GitAPIException {
+        when(mockCheckoutCommand.setName("refs/remotes/origin/mytag")).thenReturn(this.mockBranchNotFoundCommand);
+        when(mockCheckoutCommand.setName("mytag")).thenReturn(this.mockTagNotFoundCommand);
+        doReturn(this.mockGit).when(this.spyGitService).cloneRepo(Mockito.any(String.class), Mockito.any(File.class));
+        boolean thrown = false;
+        try {
+            this.spyGitService.getRepository(new GitDetails(null, "mytag", "foo"), false);
+        } catch (Exception e) {
+            // Make sure it's not this.tagNotFoundException
+            thrown = (e == this.branchNotFoundException);
+        }
+        assertTrue(thrown);
     }
 }


### PR DESCRIPTION

## Description

Unless it was as commit id, GitService.java was always specifying `/refs/remotes/origin/<branch>` for the name to checkout. This does not work with Git tags. See [Stack Overflow](https://stackoverflow.com/questions/33762575/load-content-from-tag-with-jgit). See if there is a If  a RefNotFoundException fetching a branch, and if there is, try with the name only. If that also gives an error, thrown the original exception.


## Motivation and Context
This is to allow users to visualize CWL files that referenced by a Git tag. I ran into this doing the integration with Dockstore.org and CWLViewer.

Fixes #191 

## How Has This Been Tested?
I tested this manually, by running CWLViewer locally and entering workflows that had both branches and tags in their paths.

There are no existing unit tests in this area, and I did not add any new tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
