### PR TITLE
Use Maven Central repository first

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,10 @@
 
 	<repositories>
 		<repository>
+			<id>central</id>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
+		<repository>
 			<id>jitpack.io</id>
 			<url>https://jitpack.io</url>
 		</repository>


### PR DESCRIPTION
## Description

Fix for #215 . It appears there is something weird with the `jsonld` artefacts in JitPack.io. Normally one would use Maven Central for dependencies. But it appears that the project's `pom.xml` had an entry for JitPack.io only.

## Motivation and Context

It worked without any modification in my environment (Ubuntu LTS), so I am assuming the Docker image has something different that prevents it from fetching the artefacts from Maven Central if the project specifies the `<repository>` tags.

So this change adds the Maven Central `<repository>` entry, and also puts it before JitPack's. I believe there is only one dependency coming from GitHub repositories, so it would make sense to use JitPack as the fallback for when something is not available in Maven Central.

## How Has This Been Tested?

Executed `docker build .` as instructed in the issue, and before the change it failed. Once this change was applied locally, the build worked fine.

## Screenshots (if appropriate):

N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
