### PR TITLE
CWL to graph endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.5-jdk-8-alpine
+FROM maven:3.6-jdk-8-alpine
 MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
 # Build-time metadata as defined at http://label-schema.org

--- a/src/main/java/org/commonwl/view/cwl/CWLService.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLService.java
@@ -197,7 +197,7 @@ public class CWLService {
             }
             if (!found && ! packedWorkflowId.isEmpty()) throw new WorkflowNotFoundException();
         }
-        if (! found && extractProcess(cwlFile) != CWLProcess.WORKFLOW) {
+        if (! found && extractProcess(cwlFile) == CWLProcess.WORKFLOW) {
         	// Check the current json node is a workflow
         	found = true;
         }

--- a/src/main/java/org/commonwl/view/cwl/CWLService.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLService.java
@@ -169,7 +169,7 @@ public class CWLService {
      * Note, the length of the stream is not checked.
      *  
      * @param workflowStream The workflow stream to be parsed
-     * @param packedWorkflowId The ID of the workflow object if the file is packed. <code>null</code> means the workflow is not expected to be packecd, while "" means the first workflow found is used, packed or non-packed.
+     * @param packedWorkflowId The ID of the workflow object if the file is packed. <code>null</code> means the workflow is not expected to be packed, while "" means the first workflow found is used, packed or non-packed.
      * @param defaultLabel Label to give workflow if not set
      * @return The constructed workflow object
      */

--- a/src/main/java/org/commonwl/view/workflow/WorkflowController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowController.java
@@ -407,7 +407,8 @@ public class WorkflowController {
      * Take a CWL workflow from the POST body and generate a PNG graph for it.
      * @param in The workflow CWL
      */
-    @PostMapping(value="/graph/png", produces="image/png")
+    @PostMapping(value="/graph/png", produces="image/png", 
+    		consumes={"text/yaml", "text/x-yaml", "text/plain", "application/octet-stream"}))
     @ResponseBody
     public Resource downloadGraphPngFromFile(InputStream in, HttpServletResponse response)
             throws IOException, NoSuchAlgorithmException {
@@ -417,9 +418,10 @@ public class WorkflowController {
 
     /**
      * Take a CWL workflow from the POST body and generate a SVG graph for it.
-     * @param in The workflow CWL
+     * @param in The workflow CWL as YAML text
      */
-    @PostMapping(value="/graph/svg", produces="image/svg+xml")
+    @PostMapping(value="/graph/svg", produces="image/svg+xml", 
+    		consumes={"text/yaml", "text/x-yaml", "text/plain", "application/octet-stream"})
     @ResponseBody
     public Resource downloadGraphSvgFromFile(InputStream in, HttpServletResponse response)
             throws IOException, NoSuchAlgorithmException {

--- a/src/main/java/org/commonwl/view/workflow/WorkflowController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowController.java
@@ -408,7 +408,7 @@ public class WorkflowController {
      * @param in The workflow CWL
      */
     @PostMapping(value="/graph/png", produces="image/png", 
-    		consumes={"text/yaml", "text/x-yaml", "text/plain", "application/octet-stream"}))
+    		consumes={"text/yaml", "text/x-yaml", "text/plain", "application/octet-stream"})
     @ResponseBody
     public Resource downloadGraphPngFromFile(InputStream in, HttpServletResponse response)
             throws IOException, NoSuchAlgorithmException {

--- a/src/main/java/org/commonwl/view/workflow/WorkflowController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowController.java
@@ -585,7 +585,7 @@ public class WorkflowController {
 
     private Resource getGraphFromInputStream(InputStream in, String format)
             throws IOException, NoSuchAlgorithmException {
-        Workflow workflow = cwlService.parseWorkflowNative(in, "", "workflow"); // first workflow will do
+        Workflow workflow = cwlService.parseWorkflowNative(in, null, "workflow"); // first workflow will do
         InputStream out = graphVizService.getGraphStream(workflow.getVisualisationDot(), format);
         return new InputStreamResource(out);
     }

--- a/src/main/java/org/commonwl/view/workflow/WorkflowController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowController.java
@@ -20,16 +20,20 @@
 package org.commonwl.view.workflow;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.io.InputStream;
 import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.commonwl.view.WebConfig;
+import org.commonwl.view.cwl.CWLService;
 import org.commonwl.view.cwl.CWLToolStatus;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.graphviz.GraphVizService;
@@ -48,11 +52,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.HandlerMapping;
 import org.springframework.web.servlet.ModelAndView;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
@@ -64,6 +64,7 @@ public class WorkflowController {
 
     private final WorkflowFormValidator workflowFormValidator;
     private final WorkflowService workflowService;
+    private final CWLService cwlService;
     private final GraphVizService graphVizService;
 
     /**
@@ -79,10 +80,11 @@ public class WorkflowController {
     @Autowired
     public WorkflowController(WorkflowFormValidator workflowFormValidator,
                               WorkflowService workflowService,
-            GraphVizService graphVizService) {
+            GraphVizService graphVizService, CWLService cwlService) {
         this.workflowFormValidator = workflowFormValidator;
         this.workflowService = workflowService;
         this.graphVizService = graphVizService;
+        this.cwlService = cwlService;
     }
 
     /**
@@ -394,6 +396,26 @@ public class WorkflowController {
                 queued.getTempRepresentation().getVisualisationDot(), "png");
         response.setHeader("Content-Disposition", "inline; filename=\"graph.png\"");
         return new PathResource(out);
+    }
+
+    /**
+     * Take a CWL workflow from the POST body and generate a PNG graph for it.
+     * @param in The workflow CWL
+     */
+    @PostMapping(value="/graph/png", produces="image/png")
+    @ResponseBody
+    public FileSystemResource downloadGraphPngFromFile(InputStream in,
+                                                      HttpServletResponse response) throws IOException {
+        final File tempFile = File.createTempFile("cwl", ".cwl");
+        tempFile.deleteOnExit();
+        try (FileOutputStream out = new FileOutputStream(tempFile)) {
+            IOUtils.copy(in, out);
+        }
+        System.out.println(tempFile.toPath());
+        Workflow workflow = cwlService.parseWorkflowNative(tempFile.toPath(), null);
+        response.setHeader("Content-Disposition", "inline; filename=\"graph.png\"");
+        Path out = graphVizService.getGraphPath(workflow.getID() + ".png", workflow.getVisualisationDot(), "png");
+        return new FileSystemResource(out.toFile());
     }
 
 

--- a/src/main/resources/templates/apidocs.html
+++ b/src/main/resources/templates/apidocs.html
@@ -39,7 +39,7 @@
 
                     <p>If you make anything utilizing our API, please <a href="https://gitter.im/common-workflow-language/cwlviewer" alt="Gitter Chatroom" target="_blank" rel="noopener">let us know about it</a> - we would love to see!</p>
 
-                    <p>All queries require the following header to receive a JSON response:
+                    <p>Except where noted otherwise, all queries require the following header to receive a JSON response:
                         <pre class="highlight http">accept: application/json</pre>
                     </p>
 
@@ -652,6 +652,130 @@ if addResponse.status_code == requests.codes.accepted:
 else:
     print('Error adding workflow')
 </pre>
+
+
+                    <h3 id="graphSvg">SVG sketch of CWL workflow</h3>
+                    <div class="alert alert-info"><strong>Note:</strong> This method use a brief YAML 
+                    parsing of the standalone CWL file that do not support annotations 
+                    like <kbd>label</kbd> or <kbd>doc</kbd>, and that does not check 
+                    for validity or completeness.
+                    </div>
+                    <span class="method post">POST</span>
+                    <pre>/graph/svg</pre>                    
+                    <h4>Input</h4>
+<pre class="highlight http">
+Content-Type: text/yaml
+</pre>
+<pre class="highlight yaml">
+#!/usr/bin/env cwl-runner
+  
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  usermessage: string
+
+outputs:
+  response:
+    outputSource: step0/response
+    type: File
+
+steps:
+  step0:
+    run:
+      class: CommandLineTool
+      inputs:
+        message:
+          type: string
+          inputBinding:
+            position: 1
+      baseCommand: echo
+      outputs:
+        response:
+          type: stdout
+    in:
+      message: usermessage
+    out: [response]
+</pre>
+<h4>Output</h4>
+<p><samp>Content-Type: image/svg+xml</samp></p>
+<pre class="highlight xml">
+&lt;?xml version="1.0" encoding="UTF-8" standalone="no"?&gt;
+&lt;!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd"&gt;
+&lt;svg width="450pt" height="270pt"
+     viewBox="0.00 0.00 463.00 278.00" xmlns="http://www.w3.org/2000/svg"&gt;
+	&lt;!-- ... --&gt;
+&lt;/svg&gt;
+</pre>
+                    <h4>Success</h4>
+<pre class="highlight http">
+HTTP/1.1 200 OK
+Content-Type: image/svg+xml
+</pre>
+                    <h4>Error</h4>
+                    <pre class="highlight http">HTTP/1.1 400 Bad Request</pre>
+
+
+                    <h3 id="graphSvg">PNG sketch of CWL workflow</h3>
+                    <div class="alert alert-info"><strong>Note:</strong> This method use a brief YAML 
+                    parsing of the standalone CWL file that do not support annotations 
+                    like <kbd>label</kbd> or <kbd>doc</kbd>, and that does not check 
+                    for validity or completeness.
+                    </div>
+                    <span class="method post">POST</span>
+                    <pre>/graph/png</pre>                    
+                    <h4>Input</h4>
+
+<pre class="highlight http">
+Content-Type: text/yaml
+</pre>
+<pre class="highlight yaml">
+#!/usr/bin/env cwl-runner
+  
+cwlVersion: v1.0
+class: Workflow
+
+inputs:
+  usermessage: string
+
+outputs:
+  response:
+    outputSource: step0/response
+    type: File
+
+steps:
+  step0:
+    run:
+      class: CommandLineTool
+      inputs:
+        message:
+          type: string
+          inputBinding:
+            position: 1
+      baseCommand: echo
+      outputs:
+        response:
+          type: stdout
+    in:
+      message: usermessage
+    out: [response]
+</pre>
+
+<h4>Output</h4>
+
+<pre class="highlight">
+\x89PNG\n\x1a\n\x00\x00 (binary)
+</pre>
+                    <h4>Success</h4>
+<pre class="highlight http">
+HTTP/1.1 200 OK
+Content-Type: image/png
+</pre>
+                    <h4>Error</h4>
+                    <pre class="highlight http">HTTP/1.1 400 Bad Request</pre>
+
+
+
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/apidocs.html
+++ b/src/main/resources/templates/apidocs.html
@@ -716,7 +716,7 @@ Content-Type: image/svg+xml
                     <pre class="highlight http">HTTP/1.1 400 Bad Request</pre>
 
 
-                    <h3 id="graphSvg">PNG sketch of CWL workflow</h3>
+                    <h3 id="graphPng">PNG sketch of CWL workflow</h3>
                     <div class="alert alert-info"><strong>Note:</strong> This method use a brief YAML 
                     parsing of the standalone CWL file that do not support annotations 
                     like <kbd>label</kbd> or <kbd>doc</kbd>, and that does not check 

--- a/src/main/resources/templates/apidocs.html
+++ b/src/main/resources/templates/apidocs.html
@@ -655,8 +655,8 @@ else:
 
 
                     <h3 id="graphSvg">SVG sketch of CWL workflow</h3>
-                    <div class="alert alert-info"><strong>Note:</strong> This method use a brief YAML 
-                    parsing of the standalone CWL file that do not support annotations 
+                    <div class="alert alert-info"><strong>Note:</strong> This method uses a brief YAML
+                    parsing of the standalone CWL file that does not support annotations
                     like <kbd>label</kbd> or <kbd>doc</kbd>, and that does not check 
                     for validity or completeness.
                     </div>
@@ -717,8 +717,8 @@ Content-Type: image/svg+xml
 
 
                     <h3 id="graphPng">PNG sketch of CWL workflow</h3>
-                    <div class="alert alert-info"><strong>Note:</strong> This method use a brief YAML 
-                    parsing of the standalone CWL file that do not support annotations 
+                    <div class="alert alert-info"><strong>Note:</strong> This method uses a brief YAML
+                    parsing of the standalone CWL file that does not support annotations
                     like <kbd>label</kbd> or <kbd>doc</kbd>, and that does not check 
                     for validity or completeness.
                     </div>

--- a/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
@@ -38,6 +38,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.commonwl.view.cwl.CWLService;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.graphviz.GraphVizService;
 import org.commonwl.view.researchobject.ROBundleNotFoundException;
@@ -82,7 +83,8 @@ public class WorkflowControllerTest {
         WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 Mockito.mock(WorkflowService.class),
-                Mockito.mock(GraphVizService.class));
+                Mockito.mock(GraphVizService.class),
+                Mockito.mock(CWLService.class));
 
         // Lots of hassle to make Spring Data Pageable work
         PageableHandlerMethodArgumentResolver pageableArgumentResolver =
@@ -137,7 +139,9 @@ public class WorkflowControllerTest {
         WorkflowController workflowController = new WorkflowController(
                 mockValidator,
                 mockWorkflowService,
-                Mockito.mock(GraphVizService.class));
+                Mockito.mock(GraphVizService.class),
+                Mockito.mock(CWLService.class)
+                );
         MockMvc mockMvc = MockMvcBuilders
                 .standaloneSetup(workflowController)
                 .build();
@@ -222,7 +226,8 @@ public class WorkflowControllerTest {
         WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 mockWorkflowService,
-                Mockito.mock(GraphVizService.class));
+                Mockito.mock(GraphVizService.class),
+                Mockito.mock(CWLService.class));
         MockMvc mockMvc = MockMvcBuilders
                 .standaloneSetup(workflowController)
                 .build();
@@ -290,7 +295,8 @@ public class WorkflowControllerTest {
         WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 mockWorkflowService,
-                Mockito.mock(GraphVizService.class));
+                Mockito.mock(GraphVizService.class),
+                Mockito.mock(CWLService.class));
         MockMvc mockMvc = MockMvcBuilders
                 .standaloneSetup(workflowController)
                 .build();
@@ -332,7 +338,8 @@ public class WorkflowControllerTest {
         WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 mockWorkflowService,
-                Mockito.mock(GraphVizService.class));
+                Mockito.mock(GraphVizService.class),
+                Mockito.mock(CWLService.class));
         MockMvc mockMvc = MockMvcBuilders
                 .standaloneSetup(workflowController)
                 .build();

--- a/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
@@ -386,16 +386,16 @@ public class WorkflowControllerTest {
 
         // Mock controller/MVC
         CWLService mockCWLService = Mockito.mock(CWLService.class);
-		GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
-		
-		when(graphVizService.getGraphStream(anyString(), eq("svg")))
-				.thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
-		Workflow mockWorkflow = Mockito.mock(Workflow.class);
-		when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
-		when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
-				.thenReturn(mockWorkflow);
-		
-		WorkflowController workflowController = new WorkflowController(
+        GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
+        
+        when(graphVizService.getGraphStream(anyString(), eq("svg")))
+                .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
+        Workflow mockWorkflow = Mockito.mock(Workflow.class);
+        when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
+        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
+                .thenReturn(mockWorkflow);
+        
+        WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 mockWorkflowService,
                 graphVizService,
@@ -418,16 +418,16 @@ public class WorkflowControllerTest {
 
         // Mock controller/MVC
         CWLService mockCWLService = Mockito.mock(CWLService.class);
-		GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
-		
-		when(graphVizService.getGraphStream(anyString(), eq("png")))
-				.thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
-		Workflow mockWorkflow = Mockito.mock(Workflow.class);
-		when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
-		when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
-				.thenReturn(mockWorkflow);
-		
-		WorkflowController workflowController = new WorkflowController(
+        GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
+        
+        when(graphVizService.getGraphStream(anyString(), eq("png")))
+                .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
+        Workflow mockWorkflow = Mockito.mock(Workflow.class);
+        when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
+        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
+                .thenReturn(mockWorkflow);
+        
+        WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 mockWorkflowService,
                 graphVizService,

--- a/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
@@ -386,16 +386,16 @@ public class WorkflowControllerTest {
 
         // Mock controller/MVC
         CWLService mockCWLService = Mockito.mock(CWLService.class);
-        GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
-        
-        when(graphVizService.getGraphStream(anyString(), eq("svg")))
-                .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
-        Workflow mockWorkflow = Mockito.mock(Workflow.class);
-        when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
-        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(""), anyString()))
-                .thenReturn(mockWorkflow);
-        
-        WorkflowController workflowController = new WorkflowController(
+		GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
+		
+		when(graphVizService.getGraphStream(anyString(), eq("svg")))
+				.thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
+		Workflow mockWorkflow = Mockito.mock(Workflow.class);
+		when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
+		when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
+				.thenReturn(mockWorkflow);
+		
+		WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 mockWorkflowService,
                 graphVizService,
@@ -418,16 +418,16 @@ public class WorkflowControllerTest {
 
         // Mock controller/MVC
         CWLService mockCWLService = Mockito.mock(CWLService.class);
-        GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
-        
-        when(graphVizService.getGraphStream(anyString(), eq("png")))
-                .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
-        Workflow mockWorkflow = Mockito.mock(Workflow.class);
-        when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
-        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(""), anyString()))
-                .thenReturn(mockWorkflow);
-        
-        WorkflowController workflowController = new WorkflowController(
+		GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
+		
+		when(graphVizService.getGraphStream(anyString(), eq("png")))
+				.thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
+		Workflow mockWorkflow = Mockito.mock(Workflow.class);
+		when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
+		when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
+				.thenReturn(mockWorkflow);
+		
+		WorkflowController workflowController = new WorkflowController(
                 Mockito.mock(WorkflowFormValidator.class),
                 mockWorkflowService,
                 graphVizService,

--- a/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
@@ -22,6 +22,7 @@ package org.commonwl.view.workflow;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -33,6 +34,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -373,6 +375,70 @@ public class WorkflowControllerTest {
                 .andExpect(status().isNotFound());
         mockMvc.perform(get("/graph/xdot/github.com/owner/repo/blob/branch/path/to/workflow.cwl"))
                 .andExpect(status().isNotFound());
+
+    }
+
+    @Test
+    public void downloadGraphSvgFromFile() throws Exception {
+
+        // Mock service to return a bundle file and then throw ROBundleNotFoundException
+        WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
+
+        // Mock controller/MVC
+        CWLService mockCWLService = Mockito.mock(CWLService.class);
+        GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
+        
+        when(graphVizService.getGraphStream(anyString(), eq("svg")))
+                .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
+        Workflow mockWorkflow = Mockito.mock(Workflow.class);
+        when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
+        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(""), anyString()))
+                .thenReturn(mockWorkflow);
+        
+        WorkflowController workflowController = new WorkflowController(
+                Mockito.mock(WorkflowFormValidator.class),
+                mockWorkflowService,
+                graphVizService,
+                mockCWLService);
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(workflowController)
+                .build();
+        
+        mockMvc.perform(post("/graph/svg"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("image/svg+xml"));
+
+    }
+
+    @Test
+    public void downloadGraphPngFromFile() throws Exception {
+
+        // Mock service to return a bundle file and then throw ROBundleNotFoundException
+        WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
+
+        // Mock controller/MVC
+        CWLService mockCWLService = Mockito.mock(CWLService.class);
+        GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
+        
+        when(graphVizService.getGraphStream(anyString(), eq("png")))
+                .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
+        Workflow mockWorkflow = Mockito.mock(Workflow.class);
+        when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
+        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(""), anyString()))
+                .thenReturn(mockWorkflow);
+        
+        WorkflowController workflowController = new WorkflowController(
+                Mockito.mock(WorkflowFormValidator.class),
+                mockWorkflowService,
+                graphVizService,
+                mockCWLService);
+        MockMvc mockMvc = MockMvcBuilders
+                .standaloneSetup(workflowController)
+                .build();
+        
+        mockMvc.perform(post("/graph/png"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType("image/png"));
 
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds REST resources to directly make PNG or SVG of individual CWL file `POST`ed.

This replaces #239 by merging in #240 to avoid temporary files.

## Motivation and Context
Some workflows may need to be roughly visualized even if they are not in a git repository. The native CWL parser in CWL Viewer usually gives a "good enough" diagram when further details are not needed (e.g. labels), and is faster than having to `git clone` potentially large repository.

## How Has This Been Tested?
Tested as part of [SEEK workflow](https://github.com/seek4science/seek/tree/workflow) branch.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
