### PR TITLE
Issue 236

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.22.RELEASE</version>
+		<version>2.2.2.RELEASE</version>
 		<relativePath/>
 	</parent>
 
@@ -118,6 +118,11 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<version>1.19</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>2.0.1.RELEASE</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/commonwl/view/workflow/WorkflowService.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowService.java
@@ -114,7 +114,7 @@ public class WorkflowService {
      * @return The model for the workflow
      */
     public Workflow getWorkflow(String id) {
-        return workflowRepository.findOne(id);
+        return workflowRepository.findById(id).orElse(null);
     }
 
     /**
@@ -123,7 +123,7 @@ public class WorkflowService {
      * @return The model for the queued workflow
      */
     public QueuedWorkflow getQueuedWorkflow(String id) {
-        return queuedWorkflowRepository.findOne(id);
+        return queuedWorkflowRepository.findById(id).orElse(null);
     }
 
     /**


### PR DESCRIPTION
The reported issue is related to the following case: 

https://stackoverflow.com/questions/49316751/spring-data-jpa-findone-change-to-optional-how-to-use-this

Solution:

[Editing Pom.xml]

update Spring Boot:

<parent>
   <groupId>org.springframework.boot</groupId>
   <artifactId>spring-boot-starter-parent</artifactId>
   <version>2.2.2.RELEASE</version>
   <relativePath/>
</parent>

add the following dependency for ensuring that we use the appropriate spring-data-commons version. 

<dependency>
   <groupId>org.springframework.data</groupId>
   <artifactId>spring-data-commons</artifactId>
   <version>2.0.1.RELEASE</version>
</dependency>

[WorkflowService.java]

Replace any occurrence of the findOne with findById(id).orElse(null) here:

org.commonwl.view.workflow.WorkflowRepository
org.commonwl.view.workflow.QueuedWorkflowRepository

With these changes we should expect to build successfully. 
