### PR TITLE
Upgrade to SpringBoot 2.6.1, updating unit test and code accordingly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,11 +63,6 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<version>1.30</version>
@@ -109,12 +104,6 @@
 			<version>5.13.0.202109080827-r</version>
 		</dependency>
 		<dependency>
-			<groupId>org.mockito</groupId>
-			<artifactId>mockito-all</artifactId>
-			<version>1.10.19</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<version>1.21</version>
@@ -128,6 +117,18 @@
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
 			<version>6.0.13.Final</version>
+		</dependency>
+		<!-- Test dependencies -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<dependency>
 			<groupId>org.springframework.data</groupId>
 			<artifactId>spring-data-commons</artifactId>
-			<version>2.0.1.RELEASE</version>
+			<version>2.6.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 		<ver.jsonldjava>0.13.4</ver.jsonldjava>
 		<ver.jackson>2.13.0</ver.jackson>
 		<!-- END -->
+		<log4j2.version>2.17.0</log4j2.version>
 	</properties>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.2.2.RELEASE</version>
+		<version>2.6.1</version>
 		<relativePath/>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,11 @@
 			<version>1.10.19</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>de.flapdoodle.embed</groupId>
+			<artifactId>de.flapdoodle.embed.mongo</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,11 @@
 			<artifactId>spring-data-commons</artifactId>
 			<version>2.0.1.RELEASE</version>
 		</dependency>
+		<dependency>
+			<groupId>org.hibernate.validator</groupId>
+			<artifactId>hibernate-validator</artifactId>
+			<version>6.0.13.Final</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>1.5.22.RELEASE</version>
+		<version>2.2.2.RELEASE</version>
 		<relativePath/>
 	</parent>
 
@@ -118,6 +118,11 @@
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<version>1.21</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>2.0.1.RELEASE</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
-		<jena.version>4.1.0</jena.version>
+		<jena.version>4.3.1</jena.version>
 		<!-- BEGIN should correspond to https://repo1.maven.org/maven2/org/apache/jena/jena/3.9.0/jena-3.9.0.pom -->
 		<ver.jsonldjava>0.13.4</ver.jsonldjava>
 		<ver.jackson>2.13.0</ver.jackson>
@@ -50,6 +50,7 @@
 	</repositories>
 
 	<dependencies>
+		<!-- SpringBoot -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-mongodb</artifactId>
@@ -62,16 +63,25 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<!-- Spring Data -->
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-commons</artifactId>
+			<version>2.6.0</version>
+		</dependency>
+		<!-- YAML -->
 		<dependency>
 			<groupId>org.yaml</groupId>
 			<artifactId>snakeyaml</artifactId>
 			<version>1.30</version>
 		</dependency>
+		<!-- GraphViz/dot -->
 		<dependency>
 			<groupId>com.github.jabbalaci</groupId>
 			<artifactId>graphviz-java-api</artifactId>
 			<version>f9bf94896776de6e98b5004e819b63fb4c15b15d</version>
 		</dependency>
+		<!-- For Research Objects -->
 		<dependency>
 			<groupId>org.apache.taverna.language</groupId>
 			<artifactId>taverna-robundle</artifactId>
@@ -83,14 +93,16 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<!-- JSON parsing -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 			<version>${ver.jackson}</version>
 		</dependency>
+		<!-- Jena, turtle -->
 		<dependency>
 			<groupId>org.apache.jena</groupId>
-			<artifactId>jena-osgi</artifactId>
+			<artifactId>jena-core</artifactId>
 			<version>${jena.version}</version>
 		</dependency>
 		<dependency>
@@ -98,21 +110,19 @@
 			<artifactId>jsonld-java</artifactId>
 			<version>${ver.jsonldjava}</version>
 		</dependency>
+		<!-- Git in Java -->
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>5.13.0.202109080827-r</version>
 		</dependency>
+		<!-- Compress -->
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-compress</artifactId>
 			<version>1.21</version>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-commons</artifactId>
-			<version>2.6.0</version>
-		</dependency>
+		<!-- For JSR-303, javax.validation -->
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>

--- a/src/main/java/org/commonwl/view/MongoConfig.java
+++ b/src/main/java/org/commonwl/view/MongoConfig.java
@@ -22,7 +22,7 @@ package org.commonwl.view;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.mongodb.MongoDbFactory;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.core.convert.DbRefResolver;
 import org.springframework.data.mongodb.core.convert.DefaultDbRefResolver;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
@@ -32,7 +32,7 @@ import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 public class MongoConfig {
 
     @Autowired
-    private MongoDbFactory mongoFactory;
+    private MongoDatabaseFactory mongoFactory;
 
     @Autowired
     private MongoMappingContext mongoMappingContext;

--- a/src/main/java/org/commonwl/view/WebConfig.java
+++ b/src/main/java/org/commonwl/view/WebConfig.java
@@ -27,10 +27,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
-public class WebConfig extends WebMvcConfigurerAdapter {
+public class WebConfig implements WebMvcConfigurer {
 
     /**
      * Ordered list of formats as presented on Workflow page and supported for

--- a/src/main/java/org/commonwl/view/workflow/QueuedWorkflowRepository.java
+++ b/src/main/java/org/commonwl/view/workflow/QueuedWorkflowRepository.java
@@ -17,7 +17,7 @@ public interface QueuedWorkflowRepository extends PagingAndSortingRepository<Que
      * @param retrievedFrom Details of where the queued workflow is from
      * @return The queued workflow
      */
-    @Query("{tempRepresentation.retrievedFrom: ?0}")
+    @Query("{\"tempRepresentation.retrievedFrom\": ?0}")
     QueuedWorkflow findByRetrievedFrom(GitDetails retrievedFrom);
 
     /**

--- a/src/main/java/org/commonwl/view/workflow/Workflow.java
+++ b/src/main/java/org/commonwl/view/workflow/Workflow.java
@@ -19,9 +19,9 @@
 
 package org.commonwl.view.workflow;
 
-import java.util.Date;
-import java.util.Map;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import org.commonwl.view.WebConfig;
 import org.commonwl.view.WebConfig.Format;
 import org.commonwl.view.cwl.CWLElement;
@@ -32,9 +32,8 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.format.annotation.DateTimeFormat;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Date;
+import java.util.Map;
 
 /**
  * Representation of a workflow
@@ -78,7 +77,7 @@ public class Workflow {
     // DOT graph of the contents
     private String visualisationDot;
 
-    private final String permaLinkBase = "https://w3id.org/cwl/view";
+    private static final String PERMANENT_LINK_BASE_URL = "https://w3id.org/cwl/view";
 
 	private String licenseLink;
 
@@ -244,7 +243,7 @@ public class Workflow {
      * Permalink for a particular representation of this workflow. Note that
      * resolving the permalink will use the official deployment of the CWL Viewer.
      *
-     * @see {@link https://w3id.org/cwl/view}
+     * @see <a href="https://w3id.org/cwl/view">https://w3id.org/cwl/view</a>
      * @param format
      *            Format of representation, or <code>null</code> for format-neutral
      *            permalink that supports content negotiation.
@@ -263,7 +262,7 @@ public class Workflow {
         if (format != null) {
             formatPart = formatPartSep + "format=" + format.name();
         }
-        return permaLinkBase + "/git/" + lastCommit +
+        return PERMANENT_LINK_BASE_URL + "/git/" + lastCommit +
                 "/" + retrievedFrom.getPath() + packedPart + formatPart;
     }
 
@@ -275,7 +274,7 @@ public class Workflow {
     @JsonProperty(value = "@id", index = 0)
     public String getIdentifier() {
         String packedPart = (retrievedFrom.getPackedId() != null) ? "#" + retrievedFrom.getPackedId() : "";
-        return permaLinkBase + "/git/" + lastCommit + "/" + retrievedFrom.getPath() + packedPart;
+        return PERMANENT_LINK_BASE_URL + "/git/" + lastCommit + "/" + retrievedFrom.getPath() + packedPart;
 
     }
 

--- a/src/main/java/org/commonwl/view/workflow/WorkflowService.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowService.java
@@ -114,7 +114,7 @@ public class WorkflowService {
      * @return The model for the workflow
      */
     public Workflow getWorkflow(String id) {
-        return workflowRepository.findOne(id);
+        return workflowRepository.findById(id).orElse(null);
     }
 
     /**
@@ -123,7 +123,7 @@ public class WorkflowService {
      * @return The model for the queued workflow
      */
     public QueuedWorkflow getQueuedWorkflow(String id) {
-        return queuedWorkflowRepository.findOne(id);
+        return queuedWorkflowRepository.findById(id).orElse(null);
     }
 
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,6 +26,11 @@ singleFileSizeLimit = 5242880
 # File size limit for the contents of the research object bundle (not counting external links)
 totalFileSizeLimit = 1073741824
 
+# Newer versions of Spring disallow pattern matching like '/workflows/**/*.git/{branch}/**', due
+# to the "No more pattern data allowed after {*...} or ** pattern element" error. This reverts to
+# the old behaviour.
+spring.mvc.pathmatch.matching-strategy=ant_path_matcher
+
 #=======================
 # Git API settings
 #=======================

--- a/src/test/java/org/commonwl/view/CwlViewerApplicationTests.java
+++ b/src/test/java/org/commonwl/view/CwlViewerApplicationTests.java
@@ -19,12 +19,12 @@
 
 package org.commonwl.view;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class CwlViewerApplicationTests {
 

--- a/src/test/java/org/commonwl/view/CwlViewerApplicationTests.java
+++ b/src/test/java/org/commonwl/view/CwlViewerApplicationTests.java
@@ -22,14 +22,18 @@ package org.commonwl.view;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(classes={WebConfig.class})
 public class CwlViewerApplicationTests {
 
 	@Test
-	public void contextLoads() {
+	public void contextLoads(ApplicationContext context) {
+		assertThat(context).isNotNull();
 	}
 
 }

--- a/src/test/java/org/commonwl/view/PageControllerTest.java
+++ b/src/test/java/org/commonwl/view/PageControllerTest.java
@@ -19,8 +19,8 @@
 
 package org.commonwl.view;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.servlet.view.InternalResourceViewResolver;
@@ -34,7 +34,7 @@ public class PageControllerTest {
 
     private MockMvc mockMvc;
 
-    @Before
+    @BeforeEach
     public void setup() {
         InternalResourceViewResolver viewResolver = new InternalResourceViewResolver();
         viewResolver.setPrefix("/src/main/resources/templates/");

--- a/src/test/java/org/commonwl/view/cwl/CWLElementTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLElementTest.java
@@ -19,11 +19,11 @@
 
 package org.commonwl.view.cwl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CWLElementTest {
 

--- a/src/test/java/org/commonwl/view/cwl/CWLProcessTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLProcessTest.java
@@ -19,9 +19,9 @@
 
 package org.commonwl.view.cwl;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class CWLProcessTest {
 

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -19,22 +19,28 @@
 
 package org.commonwl.view.cwl;
 
-import org.apache.jena.query.*;
+import org.apache.jena.query.Dataset;
+import org.apache.jena.query.DatasetFactory;
+import org.apache.jena.query.Query;
+import org.apache.jena.query.QueryExecution;
+import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.ResultSetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.workflow.Workflow;
 import org.commonwl.view.workflow.WorkflowOverview;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -44,12 +50,15 @@ import java.util.List;
 import java.util.Map;
 
 import static org.apache.commons.io.FileUtils.readFileToString;
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class CWLServiceTest {
 
@@ -58,7 +67,7 @@ public class CWLServiceTest {
      */
     private RDFService rdfService;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
         Model workflowModel = ModelFactory.createDefaultModel();
@@ -81,12 +90,6 @@ public class CWLServiceTest {
         Mockito.doAnswer(queryRdf).when(rdfService).runQuery(anyObject());
         Mockito.doReturn(true).when(rdfService).graphExists(anyString());
     }
-
-    /**
-     * Used for expected IOExceptions for filesize limits
-     */
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void parsePackedWorkflowNativePath() throws Exception {
@@ -180,13 +183,12 @@ public class CWLServiceTest {
     public void workflowOverSingleFileSizeLimitThrowsIOException() throws Exception {
 
         // Should throw IOException due to oversized files
-        thrown.expect(IOException.class);
-        thrown.expectMessage("File 'lobSTR-workflow.cwl' is over singleFileSizeLimit - 2 KB/0 bytes");
-
-        CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 0);
-        cwlService.parseWorkflowNative(
-                Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
-
+        Exception thrown = Assertions.assertThrows(IOException.class, () -> {
+            CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 0);
+            cwlService.parseWorkflowNative(
+                    Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
+        });
+        assertEquals("File 'lobSTR-workflow.cwl' is over singleFileSizeLimit - 2 KB/0 bytes", thrown.getMessage());
     }
 
     /**
@@ -216,19 +218,17 @@ public class CWLServiceTest {
      */
     @Test
     public void workflowOverviewOverSingleFileSizeLimitThrowsIOException() throws Exception {
-
-        // Test cwl service
-        CWLService cwlService = new CWLService(Mockito.mock(RDFService.class),
-                Mockito.mock(CWLTool.class), 0);
-
         // File to test
         File helloWorkflow = new File("src/test/resources/cwl/hello/hello.cwl");
 
-        // Should throw IOException due to oversized file
-        thrown.expect(IOException.class);
-        thrown.expectMessage(String.format("File 'hello.cwl' is over singleFileSizeLimit - %s bytes/0 bytes", 
-                helloWorkflow.length()));
-        cwlService.getWorkflowOverview(helloWorkflow);
+        // Test cwl service
+        Exception thrown = Assertions.assertThrows(IOException.class, () -> {
+            CWLService cwlService = new CWLService(Mockito.mock(RDFService.class),
+                    Mockito.mock(CWLTool.class), 0);
+            cwlService.getWorkflowOverview(helloWorkflow);
+        });
+        assertEquals(String.format("File 'hello.cwl' is over singleFileSizeLimit - %s bytes/0 bytes",
+                helloWorkflow.length()), thrown.getMessage());
 
     }
 

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -35,12 +35,9 @@ import org.commonwl.view.workflow.WorkflowOverview;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -54,12 +51,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
 public class CWLServiceTest {
 
     /**
@@ -87,8 +81,8 @@ public class CWLServiceTest {
         };
 
         this.rdfService = Mockito.spy(new RDFService("http://localhost:3030/cwlviewer/"));
-        Mockito.doAnswer(queryRdf).when(rdfService).runQuery(anyObject());
-        Mockito.doReturn(true).when(rdfService).graphExists(anyString());
+        Mockito.doAnswer(queryRdf).when(rdfService).runQuery(any());
+        Mockito.doReturn(true).when(rdfService).graphExists(any(String.class));
     }
 
     @Test
@@ -149,7 +143,7 @@ public class CWLServiceTest {
         // Mock CWLTool
         CWLTool mockCwlTool = Mockito.mock(CWLTool.class);
         File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
-        when(mockCwlTool.getRDF(anyString()))
+        when(mockCwlTool.getRDF(any(String.class)))
                 .thenReturn(readFileToString(packedWorkflowRdf));
 
         // CWLService to test

--- a/src/test/java/org/commonwl/view/cwl/RDFServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/RDFServiceTest.java
@@ -19,15 +19,15 @@
 
 package org.commonwl.view.cwl;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class RDFServiceTest {
 

--- a/src/test/java/org/commonwl/view/cwl/RDFServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/RDFServiceTest.java
@@ -19,6 +19,9 @@
 
 package org.commonwl.view.cwl;
 
+import org.commonwl.view.CwlViewerApplication;
+import org.commonwl.view.MongoConfig;
+import org.commonwl.view.WebConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,7 +31,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest
+@SpringBootTest(classes=RDFService.class)
 public class RDFServiceTest {
 
     /**

--- a/src/test/java/org/commonwl/view/docker/DockerServiceTest.java
+++ b/src/test/java/org/commonwl/view/docker/DockerServiceTest.java
@@ -19,11 +19,11 @@
 
 package org.commonwl.view.docker;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class DockerServiceTest {
 
@@ -32,7 +32,7 @@ public class DockerServiceTest {
     /**
      * New instance of DockerService
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         dockerService = new DockerService();
     }

--- a/src/test/java/org/commonwl/view/git/GitDetailsTest.java
+++ b/src/test/java/org/commonwl/view/git/GitDetailsTest.java
@@ -19,10 +19,10 @@
 
 package org.commonwl.view.git;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.commonwl.view.git.GitDetails.normaliseUrl;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class GitDetailsTest {
 

--- a/src/test/java/org/commonwl/view/git/GitSemaphoreTest.java
+++ b/src/test/java/org/commonwl/view/git/GitSemaphoreTest.java
@@ -19,10 +19,10 @@
 
 package org.commonwl.view.git;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static junit.framework.TestCase.assertFalse;
-import static junit.framework.TestCase.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class GitSemaphoreTest {
 

--- a/src/test/java/org/commonwl/view/git/GitServiceTest.java
+++ b/src/test/java/org/commonwl/view/git/GitServiceTest.java
@@ -26,13 +26,13 @@ import org.eclipse.jgit.api.CheckoutCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -50,7 +50,7 @@ public class GitServiceTest {
     private CheckoutCommand mockTagNotFoundCommand;
     private CheckoutCommand mockCheckoutCommand;
 
-    @Before
+    @BeforeEach
     public void setup() throws GitAPIException {
         GitService gitService = new GitService(null, false);
         this.spyGitService = spy(gitService);

--- a/src/test/java/org/commonwl/view/git/GitServiceTest.java
+++ b/src/test/java/org/commonwl/view/git/GitServiceTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 
 import org.eclipse.jgit.api.CheckoutCommand;
+import org.eclipse.jgit.api.CloneCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
@@ -62,6 +63,7 @@ public class GitServiceTest {
         when(this.mockGit.checkout()).thenReturn(this.mockCheckoutCommand);
         when(this.mockBranchNotFoundCommand.call()).thenThrow(branchNotFoundException);
         when(this.mockTagNotFoundCommand.call()).thenThrow(tagNotFoundException);
+        doReturn(this.mockGit).when(this.spyGitService).cloneRepo(Mockito.any(), Mockito.any());
     }
 
     @Test

--- a/src/test/java/org/commonwl/view/graphviz/GraphVizServiceTest.java
+++ b/src/test/java/org/commonwl/view/graphviz/GraphVizServiceTest.java
@@ -19,8 +19,8 @@
 
 package org.commonwl.view.graphviz;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
@@ -35,10 +35,9 @@ import java.nio.file.Paths;
 
 import javax.imageio.ImageIO;
 
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 
 public class GraphVizServiceTest {
@@ -48,15 +47,15 @@ public class GraphVizServiceTest {
     /**
      * Use a temporary directory for testing
      */
-    @Rule
-    public TemporaryFolder graphvizFolder = new TemporaryFolder();
+    @TempDir
+    public File graphvizFolder;
 
     /**	
      * Generate a service for testing using the temporary folder
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
-        graphVizService = new GraphVizService(graphvizFolder.getRoot().getAbsolutePath());
+        graphVizService = new GraphVizService(graphvizFolder.getAbsolutePath());
     }
 
     /**
@@ -177,9 +176,9 @@ public class GraphVizServiceTest {
     @Test
     public void deleteCache() throws Exception {
 
-        File png = graphvizFolder.newFile("exampleid.png");
-        File svg = graphvizFolder.newFile("exampleid.svg");
-        File dot = graphvizFolder.newFile("exampleid.dot");
+        File png = new File(graphvizFolder, "exampleid.png");
+        File svg = new File(graphvizFolder, "exampleid.svg");
+        File dot = new File(graphvizFolder, "exampleid.dot");
 
         graphVizService.deleteCache("exampleid");
 

--- a/src/test/java/org/commonwl/view/graphviz/ModelDotWriterTest.java
+++ b/src/test/java/org/commonwl/view/graphviz/ModelDotWriterTest.java
@@ -24,15 +24,15 @@ import org.commonwl.view.cwl.CWLElement;
 import org.commonwl.view.cwl.CWLProcess;
 import org.commonwl.view.cwl.CWLStep;
 import org.commonwl.view.workflow.Workflow;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ModelDotWriterTest {
 
@@ -43,7 +43,7 @@ public class ModelDotWriterTest {
      * nested workflow etc to test DOT generation
      * TODO: This is a pain, can it be made simpler?
      */
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         // Inputs

--- a/src/test/java/org/commonwl/view/researchobject/HashableAgentTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/HashableAgentTest.java
@@ -19,14 +19,14 @@
 
 package org.commonwl.view.researchobject;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import java.net.URI;
 import java.util.HashSet;
 import java.util.Set;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class HashableAgentTest {
 

--- a/src/test/java/org/commonwl/view/researchobject/ROBundleFactoryTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/ROBundleFactoryTest.java
@@ -19,6 +19,7 @@
 
 package org.commonwl.view.researchobject;
 
+import org.apache.taverna.robundle.Bundle;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.workflow.Workflow;
 import org.commonwl.view.workflow.WorkflowRepository;
@@ -29,7 +30,7 @@ import java.nio.file.Paths;
 import java.util.HashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -49,12 +50,12 @@ public class ROBundleFactoryTest {
 
         // Mocked path to a RO bundle
         ROBundleService mockROBundleService = Mockito.mock(ROBundleService.class);
-        when(mockROBundleService.saveToFile(anyObject()))
+        when(mockROBundleService.saveToFile(any()))
                 .thenReturn(Paths.get("test/path/to/check/for.zip"));
 
         // Test method retries multiple times to get workflow model before success
         WorkflowRepository mockRepository = Mockito.mock(WorkflowRepository.class);
-        when(mockRepository.findByRetrievedFrom(anyObject()))
+        when(mockRepository.findByRetrievedFrom(any(GitDetails.class)))
                 .thenReturn(null)
                 .thenReturn(null)
                 .thenReturn(validWorkflow);

--- a/src/test/java/org/commonwl/view/researchobject/ROBundleFactoryTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/ROBundleFactoryTest.java
@@ -22,13 +22,13 @@ package org.commonwl.view.researchobject;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.workflow.Workflow;
 import org.commonwl.view.workflow.WorkflowRepository;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
 import java.nio.file.Paths;
 import java.util.HashMap;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
@@ -19,10 +19,10 @@
 
 package org.commonwl.view.researchobject;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
@@ -52,10 +52,9 @@ import org.commonwl.view.graphviz.GraphVizService;
 import org.commonwl.view.workflow.Workflow;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -66,7 +65,7 @@ public class ROBundleServiceTest {
     private static ROBundleService roBundleServiceZeroSizeLimit;
     private static Workflow lobSTRdraft3;
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
         Repository mockRepo = Mockito.mock(Repository.class);
         when(mockRepo.getWorkTree()).thenReturn(new File("src/test/resources/cwl/"));
@@ -109,11 +108,11 @@ public class ROBundleServiceTest {
                 .thenReturn("@prefix cwl: <https://w3id.org/cwl/cwl#> .".getBytes());
 
         // Create new RO bundle
-        roBundleService = new ROBundleService(roBundleFolder.getRoot().toPath(),
+        roBundleService = new ROBundleService(roBundleFolder.toPath(),
                 "CWL Viewer", "https://view.commonwl.org", 5242880,
                 mockGraphvizService, mockGitService, mockRdfService,
                 Mockito.mock(GitSemaphore.class), mockCwlTool);
-        roBundleServiceZeroSizeLimit = new ROBundleService(roBundleFolder.getRoot().toPath(),
+        roBundleServiceZeroSizeLimit = new ROBundleService(roBundleFolder.toPath(),
                 "CWL Viewer", "https://view.commonwl.org", 0,
                 mockGraphvizService, mockGitService, mockRdfService,
                 Mockito.mock(GitSemaphore.class), mockCwlTool);
@@ -140,8 +139,8 @@ public class ROBundleServiceTest {
     /**
      * Use a temporary directory for testing
      */
-    @Rule
-    public TemporaryFolder roBundleFolder = new TemporaryFolder();
+    @TempDir
+    public File roBundleFolder;
 
     /**
      * Generate a Research Object bundle from lobstr and check it
@@ -204,7 +203,7 @@ public class ROBundleServiceTest {
 
         // Save and check it exists in the temporary folder
         roBundleService.saveToFile(bundle);
-        File[] fileList =  roBundleFolder.getRoot().listFiles();
+        File[] fileList =  roBundleFolder.listFiles();
         assertTrue(fileList.length == 1);
         for (File ro : fileList) {
             assertTrue(ro.getName().endsWith(".zip"));

--- a/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
+++ b/src/test/java/org/commonwl/view/researchobject/ROBundleServiceTest.java
@@ -19,24 +19,6 @@
 
 package org.commonwl.view.researchobject;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.when;
-
-import java.io.File;
-import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
 import org.apache.jena.query.ResultSet;
 import org.apache.taverna.robundle.Bundle;
 import org.apache.taverna.robundle.Bundles;
@@ -59,6 +41,21 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
+import java.io.File;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
 public class ROBundleServiceTest {
 
     private static ROBundleService roBundleService;
@@ -75,36 +72,36 @@ public class ROBundleServiceTest {
 
         // Get mock Git service
         GitService mockGitService = Mockito.mock(GitService.class);
-        when(mockGitService.getRepository(anyObject(), anyBoolean())).thenReturn(gitRepo);
+        when(mockGitService.getRepository(any(GitDetails.class), any(Boolean.class))).thenReturn(gitRepo);
 
         Set<HashableAgent> authors = new HashSet<>();
         authors.add(new HashableAgent("Mark Robinson", null, new URI("mailto:mark@example.com")));
-        when(mockGitService.getAuthors(anyObject(), anyObject()))
+        when(mockGitService.getAuthors(any(Git.class), any(String.class)))
                 .thenReturn(authors);
 
         // Mock Graphviz service
         GraphVizService mockGraphvizService = Mockito.mock(GraphVizService.class);
-        when(mockGraphvizService.getGraphPath(anyString(), anyString(), anyString()))
+        when(mockGraphvizService.getGraphPath(any(String.class), any(String.class), any(String.class)))
                 .thenReturn(Paths.get("src/test/resources/graphviz/testVis.png"))
                 .thenReturn(Paths.get("src/test/resources/graphviz/testVis.svg"));
-        when(mockGraphvizService.getGraphStream(anyString(), anyString()))
+        when(mockGraphvizService.getGraphStream(any(), any(String.class)))
         .thenReturn(getClass().getResourceAsStream("/graphviz/testVis.png"))
         .thenReturn(getClass().getResourceAsStream("/graphviz/testVis.svg"));
 
         
         // Mock CWLTool
         CWLTool mockCwlTool = Mockito.mock(CWLTool.class);
-        when(mockCwlTool.getPackedVersion(anyString()))
+        when(mockCwlTool.getPackedVersion(any(String.class)))
                 .thenReturn("cwlVersion: v1.0");
 
         // Mock RDF Service
         ResultSet emptyResult = Mockito.mock(ResultSet.class);
         when(emptyResult.hasNext()).thenReturn(false);
         RDFService mockRdfService = Mockito.mock(RDFService.class);
-        when(mockRdfService.getAuthors(anyString(), anyString())).thenReturn(emptyResult);
-        when(mockRdfService.graphExists(anyString()))
+        when(mockRdfService.getAuthors(any(String.class), any(String.class))).thenReturn(emptyResult);
+        when(mockRdfService.graphExists(any(String.class)))
                 .thenReturn(true);
-        when(mockRdfService.getModel(anyObject(), anyObject()))
+        when(mockRdfService.getModel(any(String.class), any(String.class)))
                 .thenReturn("@prefix cwl: <https://w3id.org/cwl/cwl#> .".getBytes());
 
         // Create new RO bundle

--- a/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
+++ b/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
@@ -6,10 +6,7 @@ import org.commonwl.view.WebConfig;
 import org.commonwl.view.git.GitDetails;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -17,7 +14,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 // N.B. "To use embedded mongo, the spring.mongodb.embedded.version property must now be set."
 // https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#embedded-mongo
 @SpringBootTest(
-        properties={"spring.mongodb.embedded.version=3.2.2"},
+        properties={
+                "spring.mongodb.embedded.version=3.2.2",
+                "spring.data.mongodb.port=0"
+        },
         classes={MongoConfig.class, WebConfig.class, CwlViewerApplication.class, QueuedWorkflowRepository.class}
 )
 public class QueuedWorkflowRepositoryTest {

--- a/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
+++ b/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
@@ -1,20 +1,17 @@
 package org.commonwl.view.workflow;
 
-import org.apache.jena.base.Sys;
 import org.commonwl.view.git.GitDetails;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mock;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DataMongoTest
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 public class QueuedWorkflowRepositoryTest {
 
     @Autowired

--- a/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
+++ b/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
@@ -1,17 +1,17 @@
 package org.commonwl.view.workflow;
 
+import org.commonwl.view.MongoConfig;
 import org.commonwl.view.git.GitDetails;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 @DataMongoTest
-@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes={MongoConfig.class})
 public class QueuedWorkflowRepositoryTest {
 
     @Autowired

--- a/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
+++ b/src/test/java/org/commonwl/view/workflow/QueuedWorkflowRepositoryTest.java
@@ -1,17 +1,25 @@
 package org.commonwl.view.workflow;
 
+import org.commonwl.view.CwlViewerApplication;
 import org.commonwl.view.MongoConfig;
+import org.commonwl.view.WebConfig;
 import org.commonwl.view.git.GitDetails;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@DataMongoTest
-@ContextConfiguration(classes={MongoConfig.class})
+// N.B. "To use embedded mongo, the spring.mongodb.embedded.version property must now be set."
+// https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes#embedded-mongo
+@SpringBootTest(
+        properties={"spring.mongodb.embedded.version=3.2.2"},
+        classes={MongoConfig.class, WebConfig.class, CwlViewerApplication.class, QueuedWorkflowRepository.class}
+)
 public class QueuedWorkflowRepositoryTest {
 
     @Autowired
@@ -49,6 +57,24 @@ public class QueuedWorkflowRepositoryTest {
                 .findByRetrievedFrom(queuedWorkflow.getTempRepresentation().getRetrievedFrom());
         assertNull(retrievedQueuedWorkflowAfterDelete);
 
+    }
+
+    @Test
+    public void deleteQueuedWorkflowByRetrievedFromTest2() {
+        // create stub queued workflow
+        GitDetails gitDetails = new GitDetails("test_repo_url", "test_branch", "test_path");
+        gitDetails.setPackedId("test_packedId");
+
+        Workflow workflow = new Workflow();
+        workflow.setRetrievedFrom(gitDetails);
+
+        QueuedWorkflow queuedWorkflow = new QueuedWorkflow();
+        queuedWorkflow.setTempRepresentation(workflow);
+
+        // save queued workflow
+        repository.save(queuedWorkflow);
+
+        assertNotNull(workflow);
     }
 
 }

--- a/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
@@ -46,16 +46,15 @@ import org.commonwl.view.graphviz.GraphVizService;
 import org.commonwl.view.researchobject.ROBundleNotFoundException;
 import org.eclipse.jgit.api.errors.TransportException;
 import org.eclipse.jgit.api.errors.WrongRepositoryStateException;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.PathResource;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -64,15 +63,15 @@ import org.springframework.web.servlet.view.InternalResourceViewResolver;
 /**
  * Tests the controller for workflow related functionality
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class WorkflowControllerTest {
 
     /**
      * Use a temporary directory for testing
      */
-    @Rule
-    public TemporaryFolder roBundleFolder = new TemporaryFolder();
+    @TempDir
+    public File roBundleFolder;
 
     /**
      * Get the full list of workflows
@@ -287,7 +286,7 @@ public class WorkflowControllerTest {
 
         // Mock service to return a bundle file and then throw ROBundleNotFoundException
         WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
-        File bundle = roBundleFolder.newFile("bundle.zip").getAbsoluteFile();
+        File bundle = new File(roBundleFolder, "bundle.zip").getAbsoluteFile();
         when(mockWorkflowService.getROBundle(anyObject()))
                 .thenReturn(bundle)
                 .thenReturn(bundle)

--- a/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowControllerTest.java
@@ -19,10 +19,36 @@
 
 package org.commonwl.view.workflow;
 
+import org.commonwl.view.cwl.CWLService;
+import org.commonwl.view.git.GitDetails;
+import org.commonwl.view.graphviz.GraphVizService;
+import org.commonwl.view.researchobject.ROBundleNotFoundException;
+import org.eclipse.jgit.api.errors.TransportException;
+import org.eclipse.jgit.api.errors.WrongRepositoryStateException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+import org.springframework.core.io.PathResource;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.validation.Errors;
+import org.springframework.web.servlet.view.InternalResourceViewResolver;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
 import static org.hamcrest.core.Is.is;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -32,46 +58,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.view;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
-import org.commonwl.view.cwl.CWLService;
-import org.commonwl.view.git.GitDetails;
-import org.commonwl.view.graphviz.GraphVizService;
-import org.commonwl.view.researchobject.ROBundleNotFoundException;
-import org.eclipse.jgit.api.errors.TransportException;
-import org.eclipse.jgit.api.errors.WrongRepositoryStateException;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Matchers;
-import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.PathResource;
-import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.servlet.view.InternalResourceViewResolver;
-
 /**
  * Tests the controller for workflow related functionality
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
 public class WorkflowControllerTest {
 
     /**
      * Use a temporary directory for testing
      */
     @TempDir
-    public File roBundleFolder;
+    public Path roBundleFolder;
 
     /**
      * Get the full list of workflows
@@ -114,7 +110,7 @@ public class WorkflowControllerTest {
 
         // Validator pass or fail
         WorkflowFormValidator mockValidator = Mockito.mock(WorkflowFormValidator.class);
-        when(mockValidator.validateAndParse(anyObject(), anyObject()))
+        when(mockValidator.validateAndParse(Mockito.any(WorkflowForm.class), Mockito.any(Errors.class)))
                 .thenReturn(null)
                 .thenReturn(new GitDetails("https://github.com/owner/repoName.git", "branch", "path/within"))
                 .thenReturn(new GitDetails("https://github.com/owner/repoName.git", "branch", "path/workflow.cwl"));
@@ -129,7 +125,7 @@ public class WorkflowControllerTest {
 
         // Mock workflow service returning valid workflow
         WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
-        when(mockWorkflowService.createQueuedWorkflow(anyObject()))
+        when(mockWorkflowService.createQueuedWorkflow(Mockito.any(GitDetails.class)))
                 .thenThrow(new WorkflowNotFoundException())
                 .thenThrow(new WrongRepositoryStateException("Some Error"))
                 .thenThrow(new TransportException("No SSH Key"))
@@ -207,10 +203,10 @@ public class WorkflowControllerTest {
 
         // Mock service
         WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
-        when(mockWorkflowService.getWorkflow(Matchers.<GitDetails>anyObject()))
+        when(mockWorkflowService.getWorkflow(Mockito.any(GitDetails.class)))
                 .thenReturn(mockWorkflow)
                 .thenReturn(null);
-        when(mockWorkflowService.createQueuedWorkflow(anyObject()))
+        when(mockWorkflowService.createQueuedWorkflow(Mockito.any(GitDetails.class)))
                 .thenReturn(mockQueuedWorkflow)
                 .thenThrow(new WorkflowNotFoundException())
                 .thenThrow(new WrongRepositoryStateException("Some Error"))
@@ -219,7 +215,7 @@ public class WorkflowControllerTest {
         List<WorkflowOverview> listOfTwoOverviews = new ArrayList<>();
         listOfTwoOverviews.add(new WorkflowOverview("/workflow1.cwl", "label", "doc"));
         listOfTwoOverviews.add(new WorkflowOverview("/workflow2.cwl", "label2", "doc2"));
-        when(mockWorkflowService.getWorkflowsFromDirectory(anyObject()))
+        when(mockWorkflowService.getWorkflowsFromDirectory(Mockito.any(GitDetails.class)))
                 .thenReturn(listOfTwoOverviews)
                 .thenReturn(Collections.singletonList(new WorkflowOverview("/workflow1.cwl", "label", "doc")));
 
@@ -286,8 +282,8 @@ public class WorkflowControllerTest {
 
         // Mock service to return a bundle file and then throw ROBundleNotFoundException
         WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
-        File bundle = new File(roBundleFolder, "bundle.zip").getAbsoluteFile();
-        when(mockWorkflowService.getROBundle(anyObject()))
+        File bundle = Files.createFile(roBundleFolder.resolve("bundle.zip")).toAbsolutePath().toFile();
+        when(mockWorkflowService.getROBundle(Mockito.any(GitDetails.class)))
                 .thenReturn(bundle)
                 .thenReturn(bundle)
                 .thenThrow(new ROBundleNotFoundException());
@@ -326,7 +322,7 @@ public class WorkflowControllerTest {
 
         // Mock service to return mock workflow
         WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
-        when(mockWorkflowService.getWorkflowGraph(anyString(), anyObject()))
+        when(mockWorkflowService.getWorkflowGraph(any(String.class), Mockito.any(GitDetails.class)))
                 .thenReturn(new PathResource(Paths.get("src/test/resources/graphviz/testVis.svg")))
                 .thenReturn(new PathResource(Paths.get("src/test/resources/graphviz/testVis.png")))
                 .thenReturn(new PathResource(Paths.get("src/test/resources/graphviz/testWorkflow.dot")))
@@ -387,11 +383,11 @@ public class WorkflowControllerTest {
         CWLService mockCWLService = Mockito.mock(CWLService.class);
         GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
         
-        when(graphVizService.getGraphStream(anyString(), eq("svg")))
+        when(graphVizService.getGraphStream(any(String.class), eq("svg")))
                 .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
         Workflow mockWorkflow = Mockito.mock(Workflow.class);
         when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
-        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
+        when(mockCWLService.parseWorkflowNative(any(InputStream.class), eq(null), any(String.class)))
                 .thenReturn(mockWorkflow);
         
         WorkflowController workflowController = new WorkflowController(
@@ -419,11 +415,11 @@ public class WorkflowControllerTest {
         CWLService mockCWLService = Mockito.mock(CWLService.class);
         GraphVizService graphVizService = Mockito.mock(GraphVizService.class);
         
-        when(graphVizService.getGraphStream(anyString(), eq("png")))
+        when(graphVizService.getGraphStream(any(), eq("png")))
                 .thenReturn(getClass().getResourceAsStream("/graphviz/testWorkflow.dot"));
         Workflow mockWorkflow = Mockito.mock(Workflow.class);
         when(mockWorkflow.getVisualisationDot()).thenReturn("");// Not actually dot
-        when(mockCWLService.parseWorkflowNative(Matchers.any(InputStream.class), eq(null), anyString()))
+        when(mockCWLService.parseWorkflowNative(any(InputStream.class), eq(null), any(String.class)))
                 .thenReturn(mockWorkflow);
         
         WorkflowController workflowController = new WorkflowController(

--- a/src/test/java/org/commonwl/view/workflow/WorkflowFormTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowFormTest.java
@@ -19,9 +19,9 @@
 
 package org.commonwl.view.workflow;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 
 public class WorkflowFormTest {

--- a/src/test/java/org/commonwl/view/workflow/WorkflowFormValidatorTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowFormValidatorTest.java
@@ -20,11 +20,11 @@
 package org.commonwl.view.workflow;
 
 import org.commonwl.view.git.GitDetails;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.springframework.validation.BeanPropertyBindingResult;
 import org.springframework.validation.Errors;
 
-import static org.junit.Assert.*;
+import static org.junit.jupiter.api.Assertions.*;
 
 /**
  * Tests the validator. Parsing is already checked in GithubServiceTest

--- a/src/test/java/org/commonwl/view/workflow/WorkflowJSONControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowJSONControllerTest.java
@@ -22,12 +22,12 @@ package org.commonwl.view.workflow;
 import org.commonwl.view.cwl.CWLToolStatus;
 import org.commonwl.view.cwl.CWLValidationException;
 import org.commonwl.view.git.GitDetails;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -37,16 +37,21 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * API testing
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class WorkflowJSONControllerTest {
 

--- a/src/test/java/org/commonwl/view/workflow/WorkflowJSONControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowJSONControllerTest.java
@@ -23,11 +23,8 @@ import org.commonwl.view.cwl.CWLToolStatus;
 import org.commonwl.view.cwl.CWLValidationException;
 import org.commonwl.view.git.GitDetails;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -36,10 +33,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.mockito.ArgumentMatchers.any;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -51,8 +46,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * API testing
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
 public class WorkflowJSONControllerTest {
 
     @Test
@@ -60,7 +53,7 @@ public class WorkflowJSONControllerTest {
 
         // Validator pass or fail
         WorkflowFormValidator mockValidator = Mockito.mock(WorkflowFormValidator.class);
-        when(mockValidator.validateAndParse(anyObject(), anyObject()))
+        when(mockValidator.validateAndParse(any(), any()))
                 .thenReturn(null)
                 .thenReturn(new GitDetails("https://github.com/owner/repoName.git",
                         "branch", "path/workflow.cwl"))
@@ -91,7 +84,7 @@ public class WorkflowJSONControllerTest {
         when(mockWorkflowService.getWorkflow(any(GitDetails.class)))
                 .thenReturn(mockWorkflow)
                 .thenReturn(null);
-        when(mockWorkflowService.createQueuedWorkflow(anyObject()))
+        when(mockWorkflowService.createQueuedWorkflow(any()))
                 .thenThrow(new CWLValidationException("Error"))
                 .thenReturn(mockQueuedWorkflow);
 
@@ -209,7 +202,7 @@ public class WorkflowJSONControllerTest {
         qwfSuccess.setTempRepresentation(wfSuccess);
 
         WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
-        when(mockWorkflowService.getQueuedWorkflow(anyString()))
+        when(mockWorkflowService.getQueuedWorkflow(any(String.class)))
                 .thenReturn(null)
                 .thenReturn(qwfRunning)
                 .thenReturn(qwfError)

--- a/src/test/java/org/commonwl/view/workflow/WorkflowPermalinkControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowPermalinkControllerTest.java
@@ -19,6 +19,24 @@
 
 package org.commonwl.view.workflow;
 
+import org.apache.commons.io.IOUtils;
+import org.commonwl.view.cwl.RDFService;
+import org.commonwl.view.git.GitDetails;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.io.PathResource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.file.Paths;
+import java.util.Optional;
+
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -28,28 +46,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.nio.file.Paths;
-import java.util.Optional;
-
-import org.apache.commons.io.IOUtils;
-import org.commonwl.view.cwl.RDFService;
-import org.commonwl.view.git.GitDetails;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.core.io.PathResource;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
 /**
  * Tests the controller for workflow related functionality
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class WorkflowPermalinkControllerTest {
 
@@ -59,7 +59,7 @@ public class WorkflowPermalinkControllerTest {
     private PathResource svg = new PathResource(Paths.get("src/test/resources/graphviz/testVis.svg"));
     private PathResource dot = new PathResource(Paths.get("src/test/resources/graphviz/testWorkflow.dot"));
 
-    @Before
+    @BeforeEach
     public void setUp() throws Exception {
 
         Workflow mockWorkflow = Mockito.mock(Workflow.class);

--- a/src/test/java/org/commonwl/view/workflow/WorkflowPermalinkControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowPermalinkControllerTest.java
@@ -24,22 +24,21 @@ import org.commonwl.view.cwl.RDFService;
 import org.commonwl.view.git.GitDetails;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.io.PathResource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.io.File;
 import java.io.FileInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
-import static org.mockito.Matchers.anyObject;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -49,15 +48,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Tests the controller for workflow related functionality
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest
 public class WorkflowPermalinkControllerTest {
 
+    @TempDir
+    private Path tempDir;
     private MockMvc mockMvc;
     private byte[] rdfResponse;
-    private PathResource png = new PathResource(Paths.get("src/test/resources/graphviz/testVis.png"));
-    private PathResource svg = new PathResource(Paths.get("src/test/resources/graphviz/testVis.svg"));
-    private PathResource dot = new PathResource(Paths.get("src/test/resources/graphviz/testWorkflow.dot"));
+    private final PathResource png = new PathResource(Paths.get("src/test/resources/graphviz/testVis.png"));
+    private final PathResource svg = new PathResource(Paths.get("src/test/resources/graphviz/testVis.svg"));
+    private final PathResource dot = new PathResource(Paths.get("src/test/resources/graphviz/testWorkflow.dot"));
 
     @BeforeEach
     public void setUp() throws Exception {
@@ -67,27 +66,27 @@ public class WorkflowPermalinkControllerTest {
                 .thenReturn(new GitDetails("https://github.com/MarkRobbo/workflows.git",
                         "master", "path/to/workflow.cwl"));
 
-        
-        
         WorkflowService mockWorkflowService = Mockito.mock(WorkflowService.class);
-        when(mockWorkflowService.findByCommitAndPath(anyString(), anyString(), anyObject()))
+        when(mockWorkflowService.findByCommitAndPath(any(String.class), any(String.class), any(Optional.class)))
         	.thenReturn(mockWorkflow);
 
-        when(mockWorkflowService.findRawBaseForCommit(anyString())).thenReturn(
+        when(mockWorkflowService.findRawBaseForCommit(any(String.class))).thenReturn(
         		Optional.of("https://raw.githubusercontent.com/MarkRobbo/workflows/commitidhere/"));
         
-        when(mockWorkflowService.getWorkflowGraph(eq("svg"), anyObject())).thenReturn(svg);
-        when(mockWorkflowService.getWorkflowGraph(eq("png"), anyObject())).thenReturn(png);
-        when(mockWorkflowService.getWorkflowGraph(eq("xdot"), anyObject())).thenReturn(dot);
-        when(mockWorkflowService.getROBundle(anyObject())).thenReturn(new File("src/test/resources/nonsense.zip"));
+        when(mockWorkflowService.getWorkflowGraph(eq("svg"), any(GitDetails.class))).thenReturn(svg);
+        when(mockWorkflowService.getWorkflowGraph(eq("png"), any(GitDetails.class))).thenReturn(png);
+        when(mockWorkflowService.getWorkflowGraph(eq("xdot"), any(GitDetails.class))).thenReturn(dot);
+        Path path = Files.createFile(tempDir.resolve("nonsense.zip"));
+        when(mockWorkflowService.getROBundle(any())).thenReturn(new File(path.toAbsolutePath().toString()));
 
         RDFService mockRdfService = Mockito.mock(RDFService.class);
-        when(mockRdfService.graphExists(anyString())).thenReturn(true);
+        when(mockRdfService.graphExists(any())).thenReturn(true);
 
         File turtleFile = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
-        FileInputStream fileInputStream = new FileInputStream(turtleFile);
-        rdfResponse = IOUtils.toByteArray(fileInputStream);
-        when(mockRdfService.getModel(anyString(), anyString()))
+        try (FileInputStream fileInputStream = new FileInputStream(turtleFile)) {
+            rdfResponse = IOUtils.toByteArray(fileInputStream);
+        }
+        when(mockRdfService.getModel(any(), any(String.class)))
                 .thenReturn(rdfResponse);
 
         // Mock controller/MVC

--- a/src/test/java/org/commonwl/view/workflow/WorkflowServiceTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowServiceTest.java
@@ -28,9 +28,8 @@ import org.commonwl.view.graphviz.GraphVizService;
 import org.commonwl.view.researchobject.ROBundleFactory;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.mockito.Mockito;
 
 import java.io.File;
@@ -38,8 +37,8 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 
-import static junit.framework.TestCase.assertTrue;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyObject;
 import static org.mockito.Mockito.when;
@@ -49,8 +48,8 @@ public class WorkflowServiceTest {
     /**
      * Folder for test research object bundles
      */
-    @Rule
-    public TemporaryFolder roBundleFolder = new TemporaryFolder();
+    @TempDir
+    public File roBundleFolder;
 
     /**
      * Retry the running of cwltool
@@ -124,7 +123,7 @@ public class WorkflowServiceTest {
         oldWorkflow.setRetrievedOn(new Date());
         oldWorkflow.setRetrievedFrom(githubInfo);
         oldWorkflow.setLastCommit("d46ce365f1a10c4c4d6b0caed51c6f64b84c2f63");
-        oldWorkflow.setRoBundlePath(roBundleFolder.newFile("robundle.zip").getAbsolutePath());
+        oldWorkflow.setRoBundlePath(new File(roBundleFolder, "robundle.zip").getAbsolutePath());
 
         Workflow updatedWorkflow = new Workflow("new", "This is the updated workflow",
                 new HashMap<>(), new HashMap<>(), new HashMap<>());
@@ -178,7 +177,7 @@ public class WorkflowServiceTest {
         workflow.setRetrievedFrom(new GitDetails("url", "commitID", "path"));
         workflow.setLastCommit("commitID");
 
-        String roBundlePath = roBundleFolder.newFile("bundle.zip").getAbsolutePath();
+        String roBundlePath = new File(roBundleFolder, "bundle.zip").getAbsolutePath();
         workflow.setRoBundlePath(roBundlePath);
 
         WorkflowRepository mockWorkflowRepo = Mockito.mock(WorkflowRepository.class);


### PR DESCRIPTION
(redo of https://github.com/common-workflow-language/cwlviewer/pull/280 )

The reported issue is related to the following case: 

https://stackoverflow.com/questions/49316751/spring-data-jpa-findone-change-to-optional-how-to-use-this

Solution:

[Editing Pom.xml]

update Spring Boot:

<parent>
   <groupId>org.springframework.boot</groupId>
   <artifactId>spring-boot-starter-parent</artifactId>
   <version>2.2.2.RELEASE</version>
   <relativePath/>
</parent>

add the following dependency for ensuring that we use the appropriate spring-data-commons version. 

<dependency>
   <groupId>org.springframework.data</groupId>
   <artifactId>spring-data-commons</artifactId>
   <version>2.0.1.RELEASE</version>
</dependency>

[WorkflowService.java]

Replace any occurrence of the findOne with findById(id).orElse(null) here:

org.commonwl.view.workflow.WorkflowRepository
org.commonwl.view.workflow.QueuedWorkflowRepository

With these changes we should expect to build successfully. 

- [x] upgrade to Spring Boot `2.6.1` (latest)
- [x] upgrade to JUnit 5 (comes with Spring Boot, unless we enable the JUnit 4 integration layer)
- [x] Add a javax.validation implementation
- [x] Upgrade `spring-data-commons` to `2.6.0`
- [x] Fix unit tests
- [x] Upgrade Jena
- [x] Manual testing to confirm everything works
- [x] Fix GH Actions build