### PR TITLE
Add restart:always in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ volumes:
   sparql:
 services:
   spring:
+    restart: always
     # To run from this source code instead of Docker hub,
     # disable "image:"" and enable "build:" below
     image: commonworkflowlanguage/cwlviewer:v1.2.1
@@ -34,12 +35,14 @@ services:
      - GITSTORAGE=/data/git
      - GRAPHVIZSTORAGE=/data/graphviz
   mongo:
+    restart: always
     image: mongo:3.4
     volumes:
       - type: volume
         source: mongo
         target: /data/db
   sparql:
+    restart: always
 ## For debugging, expose the Fuseki port by enabling:
 #    ports:
 #     - "3030:3030"


### PR DESCRIPTION
Make sure the docker containers defined in docker-compose.yml will be restarted automatically, e.g. after a docker daemon upgrade or restart.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Without this change, the docker containers will not be restarted automatically when docker is restarted.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
