### PR TITLE
#172 error messages should state version of cwltool being used

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,6 @@ look like a commit ID. Note that this might break previous permalinks.
 
 2017 Video overview https://youtu.be/_yjhVTmvxLU
 
-2017 Technical Report: https://doi.org/10.5281/zenodo.848163
-
 # Thanks
 
 Developers and [contributors](https://github.com/common-workflow-language/cwlviewer/graphs/contributors) include:

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ The script `load.py` (requires Python 3) can be used to restore from such JSON d
 The optional parameter `--no-commits` can be added to skip those entries that
 look like a commit ID. Note that this might break previous permalinks.
 
+# Documentation
+
+2017 Poster https://f1000research.com/posters/6-1075
+
+2017 Video overview https://youtu.be/_yjhVTmvxLU
+
+2017 Technical Report: https://doi.org/10.5281/zenodo.848163
 
 # Thanks
 

--- a/src/main/java/org/commonwl/view/workflow/WorkflowService.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowService.java
@@ -382,6 +382,7 @@ public class WorkflowService {
     public void retryCwltool(QueuedWorkflow queuedWorkflow) {
         queuedWorkflow.setMessage(null);
         queuedWorkflow.setCwltoolStatus(CWLToolStatus.RUNNING);
+        queuedWorkflow.setCwltoolVersion(queuedWorkflow.getTempRepresentation().getCwltoolVersion());
         queuedWorkflowRepository.save(queuedWorkflow);
         try {
             cwlToolRunner.createWorkflowFromQueued(queuedWorkflow);

--- a/src/main/resources/templates/loading.html
+++ b/src/main/resources/templates/loading.html
@@ -50,7 +50,7 @@
                 (excluding subworkflows)
             </p>
             <div id="cwltooldetails" class="alert alert-danger">
-                <p><strong>Error:</strong> cwltool version <span th:text="${queued.cwltoolVersion}">versionhere</span> failed to run on this workflow:</p>
+                <p><strong>Error:</strong> cwltool version <span th:text="${queued.cwltoolVersion}"></span> failed to run on this workflow:</p>
                 <pre id="errorMsg" class="text-left">Sample Error, tool failed initialisation</pre>
             </div>
             <div class="loadingWorkflowContainer">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Following #172, when there is an error in parsing a given workflow it is expected that the version of cwl tool used in parsing that workflow is returned in the error body.
I also removed a portion of redundant code `versionhere` in loading.html

## Motivation and Context
<!--- Why is this change required? What problem does it solve? --> 
The change is required because it fixes the problem of cwltoolVersion not being shown when there is a parsing error as described in #172 
<!--- If it fixes an open issue, please link to the issue here. --> #172

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> 
Firstly I made sure I reproduced the error as shown on #172. After making changes, I started up my local environment and tried to parse the same URL as used in reproducing the error. Then I looked for changes in the error body. The difference is shown in the before vs after images below
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
Previous image 
![image](https://user-images.githubusercontent.com/44432472/114580137-823c5c80-9c76-11eb-90ef-8da57a4c25ec.png)

After code change
![image](https://user-images.githubusercontent.com/44432472/114579908-3ee1ee00-9c76-11eb-98fe-01361f2ac359.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
