### PR TITLE
Ignore the docker compose override file used for dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 target/
 !.mvn/wrapper/maven-wrapper.jar
+docker-compose.override.yml
 
 ### STS ###
 .classpath


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hi, I was reviewing https://github.com/common-workflow-language/cwlviewer/pull/241, and followed the instructions from `README.md` to set up the development environment. After creating the override file for `docker-compose.yml`, I noticed it was not ignored.

Maybe we can ignore it to avoid contributors accidentally including this file in their pull requests?

## Motivation and Context

Simplify contribution workflow.

## How Has This Been Tested?

Quickly tested locally for this PR :grimacing: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
