### PR TITLE
Add small space between buttons and element under it, and align right

### DIFF
--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -160,7 +160,7 @@ digraph G {
 
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 hidden-xs">
-            <div class="graph-menu hidden-print" id="pull-right">
+            <div class="graph-menu hidden-print" id="graph-menu">
                 <button id="view-dot" class="hidden-print hidden-sm-down btn btn-primary" type="button" data-toggle="modal" data-target="#dotGraph">View DOT</button>
                 <div class="btn-group hidden-print">
                     <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Hi, I noticed that the buttons to download images were not aligned to the right. Looking at the HTML attributes and CSS file, looks like there are attributes accidentally swapped.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To have everything aligned in the UI layout.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally running the application in IntelliJ + docker.

## Screenshots (if appropriate):

Before:

![image](https://user-images.githubusercontent.com/304786/135391325-021ee25b-554a-4f61-92fc-9c08e7be7cb7.png)

After:

![image](https://user-images.githubusercontent.com/304786/135390886-99eddb7e-78d4-46c0-ac74-426a4701c5c4.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
