### PR TITLE
Add pull-right class to move/align div to the right

### DIFF
--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -160,7 +160,7 @@ digraph G {
 
         </div>
         <div class="col-lg-3 col-md-4 col-sm-6 hidden-xs">
-            <div class="graph-menu hidden-print" id="graph-menu">
+            <div class="graph-menu hidden-print pull-right" id="graph-menu">
                 <button id="view-dot" class="hidden-print hidden-sm-down btn btn-primary" type="button" data-toggle="modal" data-target="#dotGraph">View DOT</button>
                 <div class="btn-group hidden-print">
                     <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Sorry, I changed in the browser the HTML and CSS, but when committing I forgot to include the `pull-right` in the pull request, sorry!

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Now the buttons will be right-aligned (`pull-right` was accidentally used as ID, and `graph-menu` as a class; so it was just a confusion and they needed to be swapped)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
