### PR TITLE
Use Yaml SafeConstructor to prevent serialization issues

### DIFF
--- a/src/main/java/org/commonwl/view/cwl/CWLService.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLService.java
@@ -64,6 +64,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 /**
  * Provides CWL parsing for workflows to gather an overview
@@ -602,10 +603,8 @@ public class CWLService {
      * @throws IOException 
      */
     private JsonNode yamlPathToJson(Path path) throws IOException {
-        Yaml reader = new Yaml();
+        Yaml reader = new Yaml(new SafeConstructor());
         ObjectMapper mapper = new ObjectMapper();
-        Path p;
-        
         try (InputStream in = Files.newInputStream(path)) {
         	return mapper.valueToTree(reader.load(in));
         }
@@ -618,7 +617,7 @@ public class CWLService {
      * @return A JsonNode with the content of the document
      */
     private JsonNode yamlStreamToJson(InputStream yamlStream) {
-        Yaml reader = new Yaml();
+        Yaml reader = new Yaml(new SafeConstructor());
         ObjectMapper mapper = new ObjectMapper();
 		return mapper.valueToTree(reader.load(yamlStream));
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

@mr-c I've successfully reproduced an issue with serialization. From the same page with the exploit, looks like passing the `SafeConstructor` fixes it (it's a class provided by SnakeYaml that prevents certain things from being accessed when constructing objects.)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Prevent serialization issues as reported in https://github.com/common-workflow-language/cwlviewer/pull/241#issuecomment-931244268

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Locally.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

Not sure how this could be tested :+1: static analyzers will spot the issue again (assuming the static analyzers are able to comprehend that `SafeConstructor` fixes the issue)
