### PR TITLE
convert lable-schema to OCI annotations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
 FROM maven:3.6-jdk-8-alpine
 MAINTAINER Stian Soiland-Reyes <stain@apache.org>
 
-# Build-time metadata as defined at http://label-schema.org
+# Build-time metadata as defined at https://github.com/opencontainers/image-spec/blob/main/annotations.md
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
-LABEL org.label-schema.build-date=$BUILD_DATE \
-  org.label-schema.name="CWL Viewer" \
-  org.label-schema.description="Viewer of Common Workflow Language" \
-  org.label-schema.url="https://view.commonwl.org/" \
-  org.label-schema.vcs-ref=$VCS_REF \
-  org.label-schema.vcs-url="https://github.com/common-workflow-language/cwlviewer" \
-  org.label-schema.vendor="Common Workflow Language project" \
-  org.label-schema.version=$VERSION \
-  org.label-schema.schema-version="1.0"
-
+LABEL org.opencontainers.image.created=$BUILD_DATE \
+  org.opencontainers.image.title="CWL Viewer" \
+  org.opencontainers.image.description="Viewer of Common Workflow Language" \
+  org.opencontainers.image.url="https://view.commonwl.org/" \
+  org.opencontainers.image.revision=$VCS_REF \
+  org.opencontainers.image.source="https://github.com/common-workflow-language/cwlviewer" \
+  org.opencontainers.image.vendor="Common Workflow Language project" \
+  org.opencontainers.image.version=$VERSION
 
 RUN apk add --update \
   graphviz \


### PR DESCRIPTION
http://label-schema.org/rc1/ says
> DEPRECATED IN FAVOUR OF [OCI IMAGE SPEC](https://github.com/opencontainers/image-spec)