### PR TITLE
Added plug-in configuration for avoiding any usages of outdated log4j2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,30 @@
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+                                <groupId>org.apache.maven.plugins</groupId>
+                                <artifactId>maven-enforcer-plugin</artifactId>
+                                <version>3.0.0</version>
+                                <executions>
+                                  <execution>
+                                    <id>ban-bad-log4j-versions</id>
+                                    <phase>validate</phase>
+                                    <goals>
+                                      <goal>enforce</goal>
+                                    </goals>
+                                    <configuration>
+                                      <rules>
+                                        <bannedDependencies>
+                                          <excludes combine.children="append">
+                                            <exclude>org.apache.logging.log4j:log4j-core:(,2.16.0)</exclude>
+                                          </excludes>
+                                        </bannedDependencies>
+                                      </rules>
+                                      <fail>true</fail>
+                                    </configuration>
+                                  </execution>
+                                </executions>
+                              </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
some of which are subject to the RCE CVE-2021-44228 ("Log4Shell") and CVE-2021-45046

From https://gist.github.com/gunnarmorling/8026d004776313ebfc65674202134e6d/899f13f64324ff80620684d77486c71fad18ec77