### PR TITLE
Catch more exceptions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Coverage report
         run: |
           mvn prepare-package -DskipTests=true
-          mvn jacoco:report coveralls:report --no-transfer-progress -DrepoToken=$COVERALLS_SECRET -DpullRequest=${{ github.event.number }}
+          mvn --errors jacoco:report coveralls:report --no-transfer-progress -DrepoToken=$COVERALLS_SECRET -DpullRequest=${{ github.event.number }}
         env:
           CI_NAME: github
           COVERALLS_SECRET: ${{ secrets.GITHUB_TOKEN }}

--- a/src/main/java/org/commonwl/view/cwl/CWLService.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLService.java
@@ -957,6 +957,14 @@ public class CWLService {
 	private String extractDoc(Map<String, Object> cwlFile) {
 		if (cwlFile != null) {
 			if (cwlFile.containsKey(DOC)) {
+				Object doc = cwlFile.get(DOC);
+				if (doc.getClass().isAssignableFrom(String.class)) {
+					return (String) doc;
+				}
+				if (doc instanceof List<?>) {
+					List<String> docList = (List<String>) doc;
+					return String.join("", docList);
+				}
 				return (String) cwlFile.get(DOC);
 			} else if (cwlFile.containsKey(DESCRIPTION)) {
 				// This is to support older standards of cwl which use description instead of

--- a/src/main/java/org/commonwl/view/cwl/CWLService.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLService.java
@@ -871,6 +871,9 @@ public class CWLService {
 	private String extractDefault(Map<String, Object> inputOutput) {
 		if (inputOutput != null && inputOutput.containsKey(DEFAULT)) {
 			Object default_value = ((Map<String, Object>) inputOutput).get(DEFAULT);
+			if (default_value == null) {
+				return null;
+			}
 			if (Map.class.isAssignableFrom(default_value.getClass())
 					&& ((Map<String, Object>) default_value).containsKey(LOCATION)) {
 				return (String) ((Map<String, Object>) default_value).get(LOCATION);

--- a/src/main/java/org/commonwl/view/git/GitService.java
+++ b/src/main/java/org/commonwl/view/git/GitService.java
@@ -24,6 +24,7 @@ import org.commonwl.view.researchobject.HashableAgent;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.RefNotFoundException;
+import org.eclipse.jgit.api.errors.CheckoutConflictException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
@@ -50,166 +51,163 @@ import static org.apache.jena.ext.com.google.common.io.Files.createTempDir;
 @Service
 public class GitService {
 
-    private final Logger logger = LoggerFactory.getLogger(this.getClass());
+	private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    // Location to check out git repositories into
-    private Path gitStorage;
+	// Location to check out git repositories into
+	private Path gitStorage;
 
-    // Whether submodules are also cloned
-    private boolean cloneSubmodules;
+	// Whether submodules are also cloned
+	private boolean cloneSubmodules;
 
-    @Autowired
-    public GitService(@Value("${gitStorage}") Path gitStorage,
-                      @Value("${gitAPI.cloneSubmodules}") boolean cloneSubmodules) {
-        this.gitStorage = gitStorage;
-        this.cloneSubmodules = cloneSubmodules;
-    }
+	@Autowired
+	public GitService(@Value("${gitStorage}") Path gitStorage,
+			@Value("${gitAPI.cloneSubmodules}") boolean cloneSubmodules) {
+		this.gitStorage = gitStorage;
+		this.cloneSubmodules = cloneSubmodules;
+	}
 
-    /**
-     * Gets a repository, cloning into a local directory or
-     * @param gitDetails The details of the Git repository
-     * @param reuseDir Whether the cached repository can be used
-     * @return The git object for the repository
-     */
-    public Git getRepository(GitDetails gitDetails, boolean reuseDir)
-            throws GitAPIException, IOException {
-        Git repo;
-        if (reuseDir) {
-            // Base dir from configuration, name from hash of repository URL
-            String baseName = DigestUtils.sha1Hex(GitDetails.normaliseUrl(gitDetails.getRepoUrl()));
+	/**
+	 * Gets a repository, cloning into a local directory or
+	 * 
+	 * @param gitDetails The details of the Git repository
+	 * @param reuseDir   Whether the cached repository can be used
+	 * @return The git object for the repository
+	 */
+	public Git getRepository(GitDetails gitDetails, boolean reuseDir) throws GitAPIException, IOException {
+		Git repo;
+		if (reuseDir) {
+			// Base dir from configuration, name from hash of repository URL
+			String baseName = DigestUtils.sha1Hex(GitDetails.normaliseUrl(gitDetails.getRepoUrl()));
 
-            // Check if folder already exists
-            Path repoDir = gitStorage.resolve(baseName);
-            if (Files.isReadable(repoDir) && Files.isDirectory(repoDir)) {
-                repo = Git.open(repoDir.toFile());
-                repo.fetch().call();
-            } else {
-                // Create a folder and clone repository into it
-                Files.createDirectory(repoDir);
-                repo = cloneRepo(gitDetails.getRepoUrl(), repoDir.toFile());
-            }
-        } else {
-            // Another thread is already using the existing folder
-            // Must create another temporary one
-            repo = cloneRepo(gitDetails.getRepoUrl(), createTempDir());
-        }
+			// Check if folder already exists
+			Path repoDir = gitStorage.resolve(baseName);
+			if (Files.isReadable(repoDir) && Files.isDirectory(repoDir)) {
+				repo = Git.open(repoDir.toFile());
+				repo.fetch().call();
+			} else {
+				// Create a folder and clone repository into it
+				Files.createDirectory(repoDir);
+				try {
+					repo = cloneRepo(gitDetails.getRepoUrl(), repoDir.toFile());
+				} catch (CheckoutConflictException ex) {
+					repo = cloneRepo(gitDetails.getRepoUrl(), createTempDir());
+				}
+			}
+		} else {
+			// Another thread is already using the existing folder
+			// Must create another temporary one
+			repo = cloneRepo(gitDetails.getRepoUrl(), createTempDir());
+		}
 
-        // Checkout the specific branch or commit ID
-        if (repo != null) {
-            // Create a new local branch if it does not exist and not a commit ID
-            String branchOrCommitId = gitDetails.getBranch();
-            final boolean isId = ObjectId.isId(branchOrCommitId);
-            if (!isId) {
-                branchOrCommitId = "refs/remotes/origin/" + branchOrCommitId;
-            }
-            try {
-                repo.checkout()
-                        .setName(branchOrCommitId)
-                        .call();
-            }
-            catch (Exception ex) {
-                // Maybe it was a tag
-                if (!isId && ex instanceof RefNotFoundException) {
-                    final String tag = gitDetails.getBranch();
-                    try {
-                        repo.checkout()
-                                .setName(tag)
-                                .call();
-                    }
-                    catch (Exception ex2) {
-                        // Throw the first exception, to keep the same behavior as before.
-                        throw ex;
-                    }
-                }
-                else {
-                    throw ex;
-                }
-            }
-        }
+		// Checkout the specific branch or commit ID
+		if (repo != null) {
+			// Create a new local branch if it does not exist and not a commit ID
+			String branchOrCommitId = gitDetails.getBranch();
+			final boolean isId = ObjectId.isId(branchOrCommitId);
+			if (!isId) {
+				branchOrCommitId = "refs/remotes/origin/" + branchOrCommitId;
+			}
+			try {
+				repo.checkout().setName(branchOrCommitId).call();
+			} catch (Exception ex) {
+				// Maybe it was a tag
+				if (!isId && ex instanceof RefNotFoundException) {
+					final String tag = gitDetails.getBranch();
+					try {
+						repo.checkout().setName(tag).call();
+					} catch (Exception ex2) {
+						// Throw the first exception, to keep the same behavior as before.
+						throw ex;
+					}
+				} else {
+					throw ex;
+				}
+			}
+		}
 
-        return repo;
-    }
+		return repo;
+	}
 
-    /**
-     * Gets the commit ID of the HEAD for the given repository
-     * @param repo The Git repository
-     * @return The commit ID of the HEAD for the repository
-     * @throws IOException If the HEAD is detached
-     */
-    public String getCurrentCommitID(Git repo) throws IOException {
-        return repo.getRepository().findRef("HEAD").getObjectId().getName();
-    }
+	/**
+	 * Gets the commit ID of the HEAD for the given repository
+	 * 
+	 * @param repo The Git repository
+	 * @return The commit ID of the HEAD for the repository
+	 * @throws IOException If the HEAD is detached
+	 */
+	public String getCurrentCommitID(Git repo) throws IOException {
+		return repo.getRepository().findRef("HEAD").getObjectId().getName();
+	}
 
-    /**
-     * Gets a set of authors for a path in a given repository
-     * @param repo The git repository
-     * @param path The path to get commits for
-     * @return An iterable of commits
-     * @throws GitAPIException Any API errors which may occur
-     * @throws URISyntaxException Error constructing mailto link
-     */
-    public Set<HashableAgent> getAuthors(Git repo, String path) throws GitAPIException, URISyntaxException {
-        Iterable<RevCommit> logs = repo.log().addPath(path).call();
-        Set<HashableAgent> fileAuthors = new HashSet<>();
-        for (RevCommit rev : logs) {
-            // Use author first with backup of committer
-            PersonIdent author = rev.getAuthorIdent();
-            if (author == null) {
-                author = rev.getCommitterIdent();
-            }
-            // Create a new agent and add as much detail as possible
-            if (author != null) {
-                HashableAgent newAgent = new HashableAgent();
-                String name = author.getName();
-                if (name != null && name.length() > 0) {
-                    newAgent.setName(author.getName());
-                }
-                String email = author.getEmailAddress();
-                if (email != null && email.length() > 0) {
-                    newAgent.setUri(new URI("mailto:" + author.getEmailAddress()));
-                }
-                fileAuthors.add(newAgent);
-            }
-        }
-        return fileAuthors;
-    }
+	/**
+	 * Gets a set of authors for a path in a given repository
+	 * 
+	 * @param repo The git repository
+	 * @param path The path to get commits for
+	 * @return An iterable of commits
+	 * @throws GitAPIException    Any API errors which may occur
+	 * @throws URISyntaxException Error constructing mailto link
+	 */
+	public Set<HashableAgent> getAuthors(Git repo, String path) throws GitAPIException, URISyntaxException {
+		Iterable<RevCommit> logs = repo.log().addPath(path).call();
+		Set<HashableAgent> fileAuthors = new HashSet<>();
+		for (RevCommit rev : logs) {
+			// Use author first with backup of committer
+			PersonIdent author = rev.getAuthorIdent();
+			if (author == null) {
+				author = rev.getCommitterIdent();
+			}
+			// Create a new agent and add as much detail as possible
+			if (author != null) {
+				HashableAgent newAgent = new HashableAgent();
+				String name = author.getName();
+				if (name != null && name.length() > 0) {
+					newAgent.setName(author.getName());
+				}
+				String email = author.getEmailAddress();
+				if (email != null && email.length() > 0) {
+					newAgent.setUri(new URI("mailto:" + author.getEmailAddress()));
+				}
+				fileAuthors.add(newAgent);
+			}
+		}
+		return fileAuthors;
+	}
 
-    /**
-     * Transfers part of the path to the branch to fix / in branch names
-     * @param githubInfo The current Github info possibly with
-     *                   part of the branch name in the path
-     * @return A potentially corrected set of Github details,
-     *         or null if there are no slashes in the path
-     */
-    public GitDetails transferPathToBranch(GitDetails githubInfo) {
-        String path = githubInfo.getPath();
-        String branch = githubInfo.getBranch();
+	/**
+	 * Transfers part of the path to the branch to fix / in branch names
+	 * 
+	 * @param githubInfo The current Github info possibly with part of the branch
+	 *                   name in the path
+	 * @return A potentially corrected set of Github details, or null if there are
+	 *         no slashes in the path
+	 */
+	public GitDetails transferPathToBranch(GitDetails githubInfo) {
+		String path = githubInfo.getPath();
+		String branch = githubInfo.getBranch();
 
-        int firstSlash = path.indexOf("/");
-        if (firstSlash > 0) {
-            branch += "/" + path.substring(0, firstSlash);
-            path = path.substring(firstSlash + 1);
-            GitDetails newDetails = new GitDetails(githubInfo.getRepoUrl(), branch, path);
-            newDetails.setPackedId(githubInfo.getPackedId());
-            return newDetails;
-        } else {
-            return null;
-        }
-    }
+		int firstSlash = path.indexOf("/");
+		if (firstSlash > 0) {
+			branch += "/" + path.substring(0, firstSlash);
+			path = path.substring(firstSlash + 1);
+			GitDetails newDetails = new GitDetails(githubInfo.getRepoUrl(), branch, path);
+			newDetails.setPackedId(githubInfo.getPackedId());
+			return newDetails;
+		} else {
+			return null;
+		}
+	}
 
-    /**
-     * Clones a Git repository
-     * @param repoUrl the url of the Git repository
-     * @param directory the directory to clone the repo into
-     * @return a Git instance
-     * @throws GitAPIException if any error occurs cloning the repo
-     */
-    protected Git cloneRepo(String repoUrl, File directory) throws GitAPIException {
-        return Git.cloneRepository()
-                .setCloneSubmodules(cloneSubmodules)
-                .setURI(repoUrl)
-                .setDirectory(directory)
-                .setCloneAllBranches(true)
-                .call();
-    }
+	/**
+	 * Clones a Git repository
+	 * 
+	 * @param repoUrl   the url of the Git repository
+	 * @param directory the directory to clone the repo into
+	 * @return a Git instance
+	 * @throws GitAPIException if any error occurs cloning the repo
+	 */
+	protected Git cloneRepo(String repoUrl, File directory) throws GitAPIException {
+		return Git.cloneRepository().setCloneSubmodules(cloneSubmodules).setURI(repoUrl).setDirectory(directory)
+				.setCloneAllBranches(true).call();
+	}
 }

--- a/src/main/java/org/commonwl/view/graphviz/GraphVizService.java
+++ b/src/main/java/org/commonwl/view/graphviz/GraphVizService.java
@@ -23,6 +23,7 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,64 +40,73 @@ import com.github.jabbalaci.graphviz.GraphViz;
 @Service
 public class GraphVizService {
 
-    private final String graphvizStorage;
+	private final String graphvizStorage;
 
-    @Autowired
-    public GraphVizService(@Value("${graphvizStorage}") String graphvizStorage) {
-        this.graphvizStorage = graphvizStorage;
-    }
-    
-    /**
-     * Generate a graph in a specified format using GraphViz
-     * @param dot The DOT source
-     * @param format The format for the graph to be generated in, e.g. "svg", "png", "dot"
-     * @return An InputStream containing the graph in desired image format.
-     */
-    public InputStream getGraphStream(String dot, String format) {
-        // Generate graphviz image if it does not already exist
-	    GraphViz gv = new GraphViz();
-	
-	    // Different DPI and transparency for svg files
-	    if (format.equals("svg")) {
-	        gv.decreaseDpi();
-	        gv.decreaseDpi();
-	        gv.decreaseDpi();
-	        dot = dot.replace("bgcolor = \"#eeeeee\"", "bgcolor = \"transparent\"");
-	    }
-	    
-	    byte[] dotBytes = gv.getGraph(dot, format, "dot");
-	    return new ByteArrayInputStream(dotBytes);
-    }
-    
+	@Autowired
+	public GraphVizService(@Value("${graphvizStorage}") String graphvizStorage) {
+		this.graphvizStorage = graphvizStorage;
+	}
 
-    /**
-     * Generate a graph in a specified format using GraphViz
-     * @param fileName The relative name of the file to be generated in the graphvizStorage directory
-     * @param dot The DOT source
-     * @param format The format for the graph to be generated in, e.g. "svg", "png", "dot"
-     * @return The file containing the graph
-     * @throws IOException if the writing failed (e.g. out of disk space)
-     */
-    public Path getGraphPath(String fileName, String dot, String format) throws IOException {
-        // Generate graphviz image if it does not already exist
-    	Path out = Paths.get(graphvizStorage).resolve(fileName);
-    	if (!Files.exists(out)) {
-    		Files.copy(getGraphStream(dot, format), out);
-        }
-        return out;
-    }
+	/**
+	 * Generate a graph in a specified format using GraphViz
+	 * 
+	 * @param dot    The DOT source
+	 * @param format The format for the graph to be generated in, e.g. "svg", "png",
+	 *               "dot"
+	 * @return An InputStream containing the graph in desired image format.
+	 */
+	public InputStream getGraphStream(String dot, String format) {
+		// Generate graphviz image if it does not already exist
+		GraphViz gv = new GraphViz();
 
-    /**
-     * Delete the cache of workflow images for a workflow
-     * TODO: Make this more dynamic in some way, either store in workflow object or clear folder
-     * @param workflowID The ID of the workflow used for assuming file locations
-     */
-    public void deleteCache(String workflowID) {
-        File graphvizSvg = new File(graphvizStorage + "/" + workflowID + ".svg");
-        graphvizSvg.delete();
-        File graphvizPng = new File(graphvizStorage + "/" + workflowID + ".png");
-        graphvizPng.delete();
-        File graphvizXdot = new File(graphvizStorage + "/" + workflowID + ".dot");
-        graphvizXdot.delete();
-    }
+		// Different DPI and transparency for svg files
+		if (format.equals("svg")) {
+			gv.decreaseDpi();
+			gv.decreaseDpi();
+			gv.decreaseDpi();
+			dot = dot.replace("bgcolor = \"#eeeeee\"", "bgcolor = \"transparent\"");
+		}
+
+		byte[] dotBytes = gv.getGraph(dot, format, "dot");
+		return new ByteArrayInputStream(dotBytes);
+	}
+
+	/**
+	 * Generate a graph in a specified format using GraphViz
+	 * 
+	 * @param fileName The relative name of the file to be generated in the
+	 *                 graphvizStorage directory
+	 * @param dot      The DOT source
+	 * @param format   The format for the graph to be generated in, e.g. "svg",
+	 *                 "png", "dot"
+	 * @return The file containing the graph
+	 * @throws IOException if the writing failed (e.g. out of disk space)
+	 */
+	public Path getGraphPath(String fileName, String dot, String format) throws IOException {
+		// Generate graphviz image if it does not already exist
+		Path out = Paths.get(graphvizStorage).resolve(fileName);
+		try {
+			if (!Files.exists(out)) {
+				Files.copy(getGraphStream(dot, format), out);
+			}
+		} catch (FileAlreadyExistsException ex) {
+			return out;
+		}
+		return out;
+	}
+
+	/**
+	 * Delete the cache of workflow images for a workflow TODO: Make this more
+	 * dynamic in some way, either store in workflow object or clear folder
+	 * 
+	 * @param workflowID The ID of the workflow used for assuming file locations
+	 */
+	public void deleteCache(String workflowID) {
+		File graphvizSvg = new File(graphvizStorage + "/" + workflowID + ".svg");
+		graphvizSvg.delete();
+		File graphvizPng = new File(graphvizStorage + "/" + workflowID + ".png");
+		graphvizPng.delete();
+		File graphvizXdot = new File(graphvizStorage + "/" + workflowID + ".dot");
+		graphvizXdot.delete();
+	}
 }

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -58,84 +58,84 @@ import org.mockito.stubbing.Answer;
 
 public class CWLServiceTest {
 
-    /**
-     * RDFService for testing
-     */
-    private RDFService rdfService;
+	/**
+	 * RDFService for testing
+	 */
+	private RDFService rdfService;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
-        Model workflowModel = ModelFactory.createDefaultModel();
-        workflowModel.read(new ByteArrayInputStream(readFileToString(packedWorkflowRdf).getBytes()), null, "TURTLE");
-        Dataset workflowDataset = DatasetFactory.create();
-        workflowDataset.addNamedModel("https://w3id.org/cwl/view/git/549c973ccc01781595ce562dea4cedc6c9540fe0/workflows/make-to-cwl/dna.cwl#main", workflowModel);
+	@BeforeEach
+	public void setUp() throws Exception {
+		File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
+		Model workflowModel = ModelFactory.createDefaultModel();
+		workflowModel.read(new ByteArrayInputStream(readFileToString(packedWorkflowRdf).getBytes()), null, "TURTLE");
+		Dataset workflowDataset = DatasetFactory.create();
+		workflowDataset.addNamedModel(
+				"https://w3id.org/cwl/view/git/549c973ccc01781595ce562dea4cedc6c9540fe0/workflows/make-to-cwl/dna.cwl#main",
+				workflowModel);
 
-        Answer queryRdf = new Answer<ResultSet>() {
-            @Override
-            public ResultSet answer(InvocationOnMock invocation) throws Throwable {
-                Object[] args = invocation.getArguments();
-                Query query = QueryFactory.create(args[0].toString());
-                try (QueryExecution qexec = QueryExecutionFactory.create(query, workflowDataset)) {
-                    return ResultSetFactory.copyResults(qexec.execSelect());
-                }
-            }
-        };
+		Answer queryRdf = new Answer<ResultSet>() {
+			@Override
+			public ResultSet answer(InvocationOnMock invocation) throws Throwable {
+				Object[] args = invocation.getArguments();
+				Query query = QueryFactory.create(args[0].toString());
+				try (QueryExecution qexec = QueryExecutionFactory.create(query, workflowDataset)) {
+					return ResultSetFactory.copyResults(qexec.execSelect());
+				}
+			}
+		};
 
-        this.rdfService = Mockito.spy(new RDFService("http://localhost:3030/cwlviewer/"));
-        Mockito.doAnswer(queryRdf).when(rdfService).runQuery(any());
-        Mockito.doReturn(true).when(rdfService).graphExists(any(String.class));
-    }
+		this.rdfService = Mockito.spy(new RDFService("http://localhost:3030/cwlviewer/"));
+		Mockito.doAnswer(queryRdf).when(rdfService).runQuery(any());
+		Mockito.doReturn(true).when(rdfService).graphExists(any(String.class));
+	}
 
-    @Test
-    public void parsePackedWorkflowNativePath() throws Exception {
-        CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
-        Workflow dna = cwlService.parseWorkflowNative(
-                Paths.get("src/test/resources/cwl/make_to_cwl/dna.cwl"), "main");
-        assertNotNull(dna);
-        assertEquals("dna.cwl", dna.getLabel());
-        assertEquals(1, dna.getInputs().size());
-        assertEquals(1, dna.getOutputs().size());
-        assertEquals(3, dna.getSteps().size());
+	@Test
+	public void parsePackedWorkflowNativePath() throws Exception {
+		CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
+		Workflow dna = cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/make_to_cwl/dna.cwl"), "main");
+		assertNotNull(dna);
+		assertEquals("dna.cwl", dna.getLabel());
+		assertEquals(1, dna.getInputs().size());
+		assertEquals(1, dna.getOutputs().size());
+		assertEquals(3, dna.getSteps().size());
 
-    }
+	}
 
-    @Test
-    public void parsePackedWorkflowNativeStream() throws Exception {
-        CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);        
-        Workflow dna = cwlService.parseWorkflowNative(
-        		getClass().getResourceAsStream("/cwl/make_to_cwl/dna.cwl"), "main", "dna.cwl");
-        assertNotNull(dna);
-        assertEquals("dna.cwl", dna.getLabel());
-        assertEquals(1, dna.getInputs().size());
-        assertEquals(1, dna.getOutputs().size());
-        assertEquals(3, dna.getSteps().size());
+	@Test
+	public void parsePackedWorkflowNativeStream() throws Exception {
+		CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
+		Workflow dna = cwlService.parseWorkflowNative(getClass().getResourceAsStream("/cwl/make_to_cwl/dna.cwl"),
+				"main", "dna.cwl");
+		assertNotNull(dna);
+		assertEquals("dna.cwl", dna.getLabel());
+		assertEquals(1, dna.getInputs().size());
+		assertEquals(1, dna.getOutputs().size());
+		assertEquals(3, dna.getSteps().size());
 
-    }
+	}
 
-    
-    /**
-     * Test native loading parsing of a the LobSTR workflow CWL version draft-3
-     */
-    @Test
-    public void parseLobSTRDraft3WorkflowNative() throws Exception {
-        CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
-        Workflow lobSTRDraft3 = cwlService.parseWorkflowNative(
-                Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
-        testLobSTRWorkflow(lobSTRDraft3, true);
-    }
+	/**
+	 * Test native loading parsing of a the LobSTR workflow CWL version draft-3
+	 */
+	@Test
+	public void parseLobSTRDraft3WorkflowNative() throws Exception {
+		CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
+		Workflow lobSTRDraft3 = cwlService
+				.parseWorkflowNative(Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
+		testLobSTRWorkflow(lobSTRDraft3, true);
+	}
 
-    /**
-     * Test native loading parsing of a the LobSTR workflow CWL version 1.0
-     */
-    @Test
-    public void parseLobSTRv1WorkflowNative() throws Exception {
-        CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
-        Workflow lobSTRv1 = cwlService.parseWorkflowNative(
-                Paths.get("src/test/resources/cwl/lobstr-v1/lobSTR-workflow.cwl"), null);
-        testLobSTRWorkflow(lobSTRv1, true);
-    }
-    
+	/**
+	 * Test native loading parsing of a the LobSTR workflow CWL version 1.0
+	 */
+	@Test
+	public void parseLobSTRv1WorkflowNative() throws Exception {
+		CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
+		Workflow lobSTRv1 = cwlService
+				.parseWorkflowNative(Paths.get("src/test/resources/cwl/lobstr-v1/lobSTR-workflow.cwl"), null);
+		testLobSTRWorkflow(lobSTRv1, true);
+	}
+
 	/**
 	 * Test native loading parsing of optional inline types
 	 */
@@ -154,16 +154,18 @@ public class CWLServiceTest {
 		assertEquals(wkflow.getInputs().get("rfam_models").getType(), "{type=array, items=[string, File]}");
 
 	}
-	
+
 	/**
-	 * Test native loading parsing of MultipleInputFeatureRequirement using workflows
+	 * Test native loading parsing of MultipleInputFeatureRequirement using
+	 * workflows
 	 */
 	@Test
 	public void parseWorkflowMultiInboundLins() throws Exception {
 		CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
-        Workflow wkflow = cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/complex-workflow/complex-workflow-1.cwl"),
-				null);
-		assertEquals(wkflow.getSteps().get("re_tar_step").getSources().get("file_list").getSourceIDs().get(0), "touch_step");
+		Workflow wkflow = cwlService
+				.parseWorkflowNative(Paths.get("src/test/resources/cwl/complex-workflow/complex-workflow-1.cwl"), null);
+		assertEquals(wkflow.getSteps().get("re_tar_step").getSources().get("file_list").getSourceIDs().get(0),
+				"touch_step");
 		assertEquals(wkflow.getSteps().get("re_tar_step").getSources().get("file_list").getSourceIDs().get(1), "files");
 	}
 
@@ -173,163 +175,169 @@ public class CWLServiceTest {
 	@Test
 	public void parseWorkflowNestedArrayTypes() throws Exception {
 		CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
-		Workflow wkflow = cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/nested_array.cwl"),
-				null);
+		Workflow wkflow = cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/nested_array.cwl"), null);
 		assertEquals(wkflow.getInputs().get("overlap_files").getType(), "File[][]");
 		assertEquals(wkflow.getOutputs().get("freq_files").getType(), "File[][]");
 		assertEquals(true, Map.class.isAssignableFrom(wkflow.getSteps().get("dummy").getRun().getClass()));
 	}
 
-    /**
-     * Test parsing of a workflow using cwltool
-     */
-    @Test
-    public void parseWorkflowWithCwltool() throws Exception {
+	/**
+	 * Test native loading parsing of inputs with null default values
+	 */
+	@Test
+	public void parseWorkflowDefaultNullTypes() throws Exception {
+		CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
+		Workflow wkflow = cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/null_default.cwl"), null);
+		assertEquals(wkflow.getInputs().get("overlap_files").getDefaultVal(), null);
+		assertEquals(wkflow.getSteps().get("dummy").getSources().get("nested_array").getDefaultVal(), null);
+	}
 
-        // Mock CWLTool
-        CWLTool mockCwlTool = Mockito.mock(CWLTool.class);
-        File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
-        when(mockCwlTool.getRDF(any(String.class)))
-                .thenReturn(readFileToString(packedWorkflowRdf));
+	/**
+	 * Test parsing of a workflow using cwltool
+	 */
+	@Test
+	public void parseWorkflowWithCwltool() throws Exception {
 
-        // CWLService to test
-        CWLService cwlService = new CWLService(rdfService, mockCwlTool, 5242880);
+		// Mock CWLTool
+		CWLTool mockCwlTool = Mockito.mock(CWLTool.class);
+		File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
+		when(mockCwlTool.getRDF(any(String.class))).thenReturn(readFileToString(packedWorkflowRdf));
 
-        GitDetails gitInfo = new GitDetails("https://github.com/common-workflow-language/workflows.git",
-                "549c973ccc01781595ce562dea4cedc6c9540fe0", "workflows/make-to-cwl/dna.cwl");
-        Workflow basicModel = new Workflow();
-        basicModel.setRetrievedFrom(gitInfo);
-        gitInfo.setPackedId("main");
-        basicModel.setLastCommit("549c973ccc01781595ce562dea4cedc6c9540fe0");
+		// CWLService to test
+		CWLService cwlService = new CWLService(rdfService, mockCwlTool, 5242880);
 
-        // Parse the workflow
-        Workflow workflow = cwlService.parseWorkflowWithCwltool(basicModel,
-                Paths.get("src/test/resources/cwl/make_to_cwl/dna.cwl"), Paths.get("src/test/resources/cwl/make_to_cwl"));
+		GitDetails gitInfo = new GitDetails("https://github.com/common-workflow-language/workflows.git",
+				"549c973ccc01781595ce562dea4cedc6c9540fe0", "workflows/make-to-cwl/dna.cwl");
+		Workflow basicModel = new Workflow();
+		basicModel.setRetrievedFrom(gitInfo);
+		gitInfo.setPackedId("main");
+		basicModel.setLastCommit("549c973ccc01781595ce562dea4cedc6c9540fe0");
 
-        // Check basic information
-        assertNotNull(workflow);
-        assertEquals(1, workflow.getInputs().size());
-        assertEquals(1, workflow.getOutputs().size());
-        assertEquals(3, workflow.getSteps().size());
-        File expectedDotCode = new File("src/test/resources/cwl/make_to_cwl/visualisation.dot");
-        assertEquals(readFileToString(expectedDotCode), workflow.getVisualisationDot());
+		// Parse the workflow
+		Workflow workflow = cwlService.parseWorkflowWithCwltool(basicModel,
+				Paths.get("src/test/resources/cwl/make_to_cwl/dna.cwl"),
+				Paths.get("src/test/resources/cwl/make_to_cwl"));
 
-    }
+		// Check basic information
+		assertNotNull(workflow);
+		assertEquals(1, workflow.getInputs().size());
+		assertEquals(1, workflow.getOutputs().size());
+		assertEquals(3, workflow.getSteps().size());
+		File expectedDotCode = new File("src/test/resources/cwl/make_to_cwl/visualisation.dot");
+		assertEquals(readFileToString(expectedDotCode), workflow.getVisualisationDot());
 
-    /**
-     * Test IOException is thrown when files are over limit
-     */
-    @Test
-    public void workflowOverSingleFileSizeLimitThrowsIOException() throws Exception {
+	}
 
-        // Should throw IOException due to oversized files
-        Exception thrown = Assertions.assertThrows(IOException.class, () -> {
-            CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 0);
-            cwlService.parseWorkflowNative(
-                    Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
-        });
-        assertEquals("File 'lobSTR-workflow.cwl' is over singleFileSizeLimit - 2 KB/0 bytes", thrown.getMessage());
-    }
+	/**
+	 * Test IOException is thrown when files are over limit
+	 */
+	@Test
+	public void workflowOverSingleFileSizeLimitThrowsIOException() throws Exception {
 
-    /**
-     * Test retrieval of a workflow overview for hello world example in cwl
-     */
-    @Test
-    public void getHelloWorkflowOverview() throws Exception {
+		// Should throw IOException due to oversized files
+		Exception thrown = Assertions.assertThrows(IOException.class, () -> {
+			CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 0);
+			cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
+		});
+		assertEquals("File 'lobSTR-workflow.cwl' is over singleFileSizeLimit - 2 KB/0 bytes", thrown.getMessage());
+	}
 
-        // Test cwl service
-        CWLService cwlService = new CWLService(Mockito.mock(RDFService.class),
-                Mockito.mock(CWLTool.class), 5242880);
+	/**
+	 * Test retrieval of a workflow overview for hello world example in cwl
+	 */
+	@Test
+	public void getHelloWorkflowOverview() throws Exception {
 
-        // Run workflow overview
-        File helloWorkflow = new File("src/test/resources/cwl/hello/hello.cwl");
-        WorkflowOverview hello = cwlService.getWorkflowOverview(helloWorkflow);
-        assertNotNull(hello);
+		// Test cwl service
+		CWLService cwlService = new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 5242880);
 
-        // No docs for this workflow
-        assertEquals("Hello World", hello.getLabel());
-        assertEquals("Puts a message into a file using echo", hello.getDoc());
-        assertEquals("/hello.cwl", hello.getFileName());
+		// Run workflow overview
+		File helloWorkflow = new File("src/test/resources/cwl/hello/hello.cwl");
+		WorkflowOverview hello = cwlService.getWorkflowOverview(helloWorkflow);
+		assertNotNull(hello);
 
-    }
+		// No docs for this workflow
+		assertEquals("Hello World", hello.getLabel());
+		assertEquals("Puts a message into a file using echo", hello.getDoc());
+		assertEquals("/hello.cwl", hello.getFileName());
 
-    /**
-     * Test IOException is thrown when files are over limit with getWorkflowOverview
-     */
-    @Test
-    public void workflowOverviewOverSingleFileSizeLimitThrowsIOException() throws Exception {
-        // File to test
-        File helloWorkflow = new File("src/test/resources/cwl/hello/hello.cwl");
+	}
 
-        // Test cwl service
-        Exception thrown = Assertions.assertThrows(IOException.class, () -> {
-            CWLService cwlService = new CWLService(Mockito.mock(RDFService.class),
-                    Mockito.mock(CWLTool.class), 0);
-            cwlService.getWorkflowOverview(helloWorkflow);
-        });
-        assertEquals(String.format("File 'hello.cwl' is over singleFileSizeLimit - %s bytes/0 bytes",
-                helloWorkflow.length()), thrown.getMessage());
+	/**
+	 * Test IOException is thrown when files are over limit with getWorkflowOverview
+	 */
+	@Test
+	public void workflowOverviewOverSingleFileSizeLimitThrowsIOException() throws Exception {
+		// File to test
+		File helloWorkflow = new File("src/test/resources/cwl/hello/hello.cwl");
 
-    }
+		// Test cwl service
+		Exception thrown = Assertions.assertThrows(IOException.class, () -> {
+			CWLService cwlService = new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 0);
+			cwlService.getWorkflowOverview(helloWorkflow);
+		});
+		assertEquals(String.format("File 'hello.cwl' is over singleFileSizeLimit - %s bytes/0 bytes",
+				helloWorkflow.length()), thrown.getMessage());
 
-    /**
-     * Get workflow overviews from a packed file
-     * TODO: Get better example with multiple workflows with label/doc
-     */
-    @Test
-    public void workflowOverviewsFromPackedFile() throws Exception {
-        CWLService cwlService = new CWLService(Mockito.mock(RDFService.class),
-                Mockito.mock(CWLTool.class), 5242880);
-        File packedFile = new File("src/test/resources/cwl/make_to_cwl/dna.cwl");
-        assertTrue(cwlService.isPacked(packedFile));
-        List<WorkflowOverview> overviews = cwlService.getWorkflowOverviewsFromPacked(packedFile);
-        assertEquals(1, overviews.size());
-        assertEquals("main", overviews.get(0).getFileName());
-        assertNull(overviews.get(0).getLabel());
-        assertNull(overviews.get(0).getDoc());
-    }
+	}
 
-    /**
-     * Validate a LobSTR workflow
-     * See: https://github.com/common-workflow-language/workflows/tree/master/workflows/lobSTR
-     */
-    private void testLobSTRWorkflow(Workflow lobSTR, boolean nativeParsed) throws Exception {
+	/**
+	 * Get workflow overviews from a packed file TODO: Get better example with
+	 * multiple workflows with label/doc
+	 */
+	@Test
+	public void workflowOverviewsFromPackedFile() throws Exception {
+		CWLService cwlService = new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 5242880);
+		File packedFile = new File("src/test/resources/cwl/make_to_cwl/dna.cwl");
+		assertTrue(cwlService.isPacked(packedFile));
+		List<WorkflowOverview> overviews = cwlService.getWorkflowOverviewsFromPacked(packedFile);
+		assertEquals(1, overviews.size());
+		assertEquals("main", overviews.get(0).getFileName());
+		assertNull(overviews.get(0).getLabel());
+		assertNull(overviews.get(0).getDoc());
+	}
 
-        // Overall not null
-        assertNotNull(lobSTR);
+	/**
+	 * Validate a LobSTR workflow See:
+	 * https://github.com/common-workflow-language/workflows/tree/master/workflows/lobSTR
+	 */
+	private void testLobSTRWorkflow(Workflow lobSTR, boolean nativeParsed) throws Exception {
 
-        // Input Tests
-        Map<String, CWLElement> inputs = lobSTR.getInputs();
-        assertNotNull(inputs);
-        assertEquals(8, inputs.size());
-        assertNotNull(inputs.get("strinfo"));
-        assertEquals("File", inputs.get("strinfo").getType());
-        assertNotNull(inputs.get("p2"));
-        assertEquals("File[]?", inputs.get("p2").getType());
-        assertNotNull(inputs.get("rg-sample"));
-        assertEquals("Use this in the read group SM tag", inputs.get("rg-sample").getDoc());
+		// Overall not null
+		assertNotNull(lobSTR);
 
-        // Step tests
-        Map<String, CWLStep> steps = lobSTR.getSteps();
-        assertNotNull(steps);
-        assertEquals(4, steps.size());
-        assertNotNull(steps.get("lobSTR"));
-        assertEquals("lobSTR-tool.cwl", steps.get("lobSTR").getRun());
-        assertNotNull(steps.get("samindex"));
-        assertTrue(steps.get("samindex").getSources().get("input").getSourceIDs().contains("samsort"));
+		// Input Tests
+		Map<String, CWLElement> inputs = lobSTR.getInputs();
+		assertNotNull(inputs);
+		assertEquals(8, inputs.size());
+		assertNotNull(inputs.get("strinfo"));
+		assertEquals("File", inputs.get("strinfo").getType());
+		assertNotNull(inputs.get("p2"));
+		assertEquals("File[]?", inputs.get("p2").getType());
+		assertNotNull(inputs.get("rg-sample"));
+		assertEquals("Use this in the read group SM tag", inputs.get("rg-sample").getDoc());
 
-        // Output tests
-        Map<String, CWLElement> outputs = lobSTR.getOutputs();
-        assertNotNull(outputs);
-        assertEquals(4, outputs.size());
-        assertNotNull(outputs.get("bam_stats"));
-        assertEquals("File", outputs.get("bam_stats").getType());
-        assertTrue(outputs.get("bam").getSourceIDs().contains("samindex"));
+		// Step tests
+		Map<String, CWLStep> steps = lobSTR.getSteps();
+		assertNotNull(steps);
+		assertEquals(4, steps.size());
+		assertNotNull(steps.get("lobSTR"));
+		assertEquals("lobSTR-tool.cwl", steps.get("lobSTR").getRun());
+		assertNotNull(steps.get("samindex"));
+		assertTrue(steps.get("samindex").getSources().get("input").getSourceIDs().contains("samsort"));
 
-        // Extra tests if parsing is done with cwltool
-        if (!nativeParsed) {
-            assertEquals(CWLProcess.COMMANDLINETOOL, steps.get("lobSTR").getRunType());
-        }
-    }
+		// Output tests
+		Map<String, CWLElement> outputs = lobSTR.getOutputs();
+		assertNotNull(outputs);
+		assertEquals(4, outputs.size());
+		assertNotNull(outputs.get("bam_stats"));
+		assertEquals("File", outputs.get("bam_stats").getType());
+		assertTrue(outputs.get("bam").getSourceIDs().contains("samindex"));
+
+		// Extra tests if parsing is done with cwltool
+		if (!nativeParsed) {
+			assertEquals(CWLProcess.COMMANDLINETOOL, steps.get("lobSTR").getRunType());
+		}
+	}
 
 }

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -264,6 +264,23 @@ public class CWLServiceTest {
 	}
 
 	/**
+	 * Test retrieval of a workflow overview with an array ``doc`` field
+	 */
+	@Test
+	public void getHelloWorkflowOverviewDocList() throws Exception {
+
+		// Test cwl service
+		CWLService cwlService = new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 5242880);
+
+		// Run workflow overview
+		File helloWorkflow = new File("src/test/resources/cwl/hello/hello_doclist.cwl");
+		WorkflowOverview hello = cwlService.getWorkflowOverview(helloWorkflow);
+		assertNotNull(hello);
+		assertEquals("Puts a message into a file using echo. Even more doc", hello.getDoc());
+
+	}
+
+	/**
 	 * Test IOException is thrown when files are over limit with getWorkflowOverview
 	 */
 	@Test

--- a/src/test/resources/cwl/hello/hello_doclist.cwl
+++ b/src/test/resources/cwl/hello/hello_doclist.cwl
@@ -1,0 +1,37 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.0
+$graph:
+- id: echocmd
+  class: CommandLineTool
+  inputs:
+    echo-in:
+      type: string
+      label: "Message"
+      doc: "The message to print"
+      default: "Hello World"
+      inputBinding: {}
+  outputs:
+    echo-out:
+      type: stdout
+      label: "Printed Message"
+      doc: "The file containing the message"
+  baseCommand: echo
+  stdout: messageout.txt
+
+- id: main
+  class: Workflow
+  label: "Hello World"
+  doc:
+    - "Puts a message into a file using echo. "
+    - "Even more doc"
+  inputs: []
+  outputs:
+    output:
+      type: File
+      outputSource: step0/echo-out
+  steps:
+    step0:
+      run: "#echocmd"
+      in: []
+      out: [echo-out]

--- a/src/test/resources/cwl/null_default.cwl
+++ b/src/test/resources/cwl/null_default.cwl
@@ -1,0 +1,50 @@
+cwlVersion: v1.2
+class: Workflow
+requirements:
+  InlineJavascriptRequirement: {}
+
+inputs:
+  overlap_files:
+    default: null
+    type:
+      - "null"
+      - type: array
+        items:
+          type: array
+          items: File
+
+outputs:
+  freq_files:
+    type:
+      type: array
+      items:
+        type: array
+        items: File
+    outputSource: dummy/freq_files
+
+steps:
+  dummy:
+    in:
+      nested_array:
+        source: overlap_files
+        default: null
+    run:
+      class: ExpressionTool
+      inputs:
+        nested_array:
+          type:
+            - "null"
+            - type: array
+              items:
+                type: array
+                items: File
+      expression: |
+        ${ return {"freq_files": inputs.nested_array }; }
+      outputs:
+        freq_files:
+          type:
+            type: array
+            items:
+              type: array
+              items: File
+    out: [ freq_files ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- graph fetching: be more resilient if the graph was created in another thread (`java.nio.file.FileAlreadyExistsException` in logs )
- if there is a checkout conflict, switch to another directory for the checkout (`org.eclipse.jgit.errors.CheckoutConflictException`)
- cope with null default values (`java.lang.NullPointerException: Cannot invoke "Object.getClass()" because "default_value" is null`)
- doc field can also be a list of strings
```
java.lang.ClassCastException: class java.util.ArrayList cannot be cast to class java.lang.String (java.util.ArrayList and java.lang.String are in module java.base of loader 'bootstrap')
	at org.commonwl.view.cwl.CWLService.extractDoc(CWLService.java:961)
```
## Motivation and Context
Fix many exceptions as seen in the logs

## How Has This Been Tested?
- Unit tests added or adjusted for the `null` default value and the `doc` as a list of strings

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
