### PR TITLE
Improve license visualization

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
+    <!-- For SPDX license identifiers -->
+    <dependency>
+      <groupId>com.github.tbouron</groupId>
+      <artifactId>spdx-license-checker</artifactId>
+      <version>1.0.0</version>
+    </dependency>
     <!-- Test dependencies -->
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/org/commonwl/view/git/GitConfig.java
+++ b/src/main/java/org/commonwl/view/git/GitConfig.java
@@ -22,19 +22,17 @@ public class GitConfig {
     RestTemplate restTemplate = new RestTemplate();
     ObjectNode jsonLicenses =
         restTemplate.getForObject(LicenseUtils.SPDX_LICENSES_JSON_URL, ObjectNode.class);
-    if (jsonLicenses != null) {
-      Map<String, String> licenseMap = new HashMap<>();
-      for (JsonNode license : jsonLicenses.withArray("licenses")) {
-        String spdxURL = license.get("reference").asText();
-        for (JsonNode alias : license.withArray("seeAlso")) {
-          licenseMap.put(
-              StringUtils.stripEnd(alias.asText().replace("http://", "https://"), "/"), spdxURL);
-        }
-      }
-      return licenseMap;
-    } else {
+    if (jsonLicenses == null) {
       throw new GitLicenseException(
-          "Failed to load SPDX licenses from " + LicenseUtils.SPDX_LICENSES_JSON_URL);
+              "Failed to load SPDX licenses from " + LicenseUtils.SPDX_LICENSES_JSON_URL);
+    }
+    Map<String, String> licenseMap = new HashMap<>();
+    for (JsonNode license : jsonLicenses.withArray("licenses")) {
+      String spdxURL = license.get("reference").asText();
+      for (JsonNode alias : license.withArray("seeAlso")) {
+        licenseMap.put(
+            StringUtils.stripEnd(alias.asText().replace("http://", "https://"), "/"), spdxURL);
+      }
     }
   }
 }

--- a/src/main/java/org/commonwl/view/git/GitConfig.java
+++ b/src/main/java/org/commonwl/view/git/GitConfig.java
@@ -28,11 +28,12 @@ public class GitConfig {
     }
     Map<String, String> licenseMap = new HashMap<>();
     for (JsonNode license : jsonLicenses.withArray("licenses")) {
-      String spdxURL = license.get("reference").asText();
+      String spdxURL = LicenseUtils.SPDX_LICENSES_PREFIX + license.get("licenseId").asText();
       for (JsonNode alias : license.withArray("seeAlso")) {
         licenseMap.put(
             StringUtils.stripEnd(alias.asText().replace("http://", "https://"), "/"), spdxURL);
       }
     }
+    return licenseMap;
   }
 }

--- a/src/main/java/org/commonwl/view/git/GitConfig.java
+++ b/src/main/java/org/commonwl/view/git/GitConfig.java
@@ -1,0 +1,40 @@
+package org.commonwl.view.git;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.commonwl.view.util.LicenseUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.WebApplicationContext;
+
+@Configuration
+public class GitConfig {
+
+  @Bean
+  @Scope(WebApplicationContext.SCOPE_APPLICATION)
+  public Map<String, String> licenseVocab() {
+    RestTemplate restTemplate = new RestTemplate();
+    ObjectNode jsonLicenses =
+        restTemplate.getForObject(LicenseUtils.SPDX_LICENSES_JSON_URL, ObjectNode.class);
+    if (jsonLicenses != null) {
+      Map<String, String> licenseMap = new HashMap<>();
+      for (JsonNode license : jsonLicenses.withArray("licenses")) {
+        String spdxURL = license.get("reference").asText();
+        for (JsonNode alias : license.withArray("seeAlso")) {
+          licenseMap.put(
+              StringUtils.stripEnd(alias.asText().replace("http://", "https://"), "/"), spdxURL);
+        }
+      }
+      return licenseMap;
+    } else {
+      throw new GitLicenseException(
+          "Failed to load SPDX licenses from " + LicenseUtils.SPDX_LICENSES_JSON_URL);
+    }
+  }
+}

--- a/src/main/java/org/commonwl/view/git/GitDetails.java
+++ b/src/main/java/org/commonwl/view/git/GitDetails.java
@@ -22,16 +22,15 @@ package org.commonwl.view.git;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.commonwl.view.util.LicenseUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Objects;
+import org.commonwl.view.util.LicenseUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Represents all the parameters necessary to access a file/directory with Git */
 @JsonIgnoreProperties(
@@ -323,7 +322,7 @@ public class GitDetails implements Serializable {
         }
         String key = jsonLicenses.withArray("licenses").get(0).get("key").asText();
         if (!"other".equals(key)) {
-          return LicenseUtils.SPDX_PREFIX
+          return LicenseUtils.SPDX_LICENSES_PREFIX
               + jsonLicenses.withArray("licenses").get(0).get("spdx_id").asText();
         } else {
           return licenseLink;

--- a/src/main/java/org/commonwl/view/git/GitDetails.java
+++ b/src/main/java/org/commonwl/view/git/GitDetails.java
@@ -22,14 +22,16 @@ package org.commonwl.view.git;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.commonwl.view.util.LicenseUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Objects;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Represents all the parameters necessary to access a file/directory with Git */
 @JsonIgnoreProperties(
@@ -38,8 +40,6 @@ import org.slf4j.LoggerFactory;
 public class GitDetails implements Serializable {
 
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
-
-  private static final String SPDX_PREFIX = "https://spdx.org/licenses/";
 
   private String repoUrl;
   private String branch;
@@ -323,7 +323,8 @@ public class GitDetails implements Serializable {
         }
         String key = jsonLicenses.withArray("licenses").get(0).get("key").asText();
         if (!"other".equals(key)) {
-          return SPDX_PREFIX + jsonLicenses.withArray("licenses").get(0).get("spdx_id").asText();
+          return LicenseUtils.SPDX_PREFIX
+              + jsonLicenses.withArray("licenses").get(0).get("spdx_id").asText();
         } else {
           return licenseLink;
         }

--- a/src/main/java/org/commonwl/view/util/LicenseUtils.java
+++ b/src/main/java/org/commonwl/view/util/LicenseUtils.java
@@ -1,0 +1,5 @@
+package org.commonwl.view.util;
+
+public class LicenseUtils {
+  public static final String SPDX_PREFIX = "https://spdx.org/licenses/";
+}

--- a/src/main/java/org/commonwl/view/util/LicenseUtils.java
+++ b/src/main/java/org/commonwl/view/util/LicenseUtils.java
@@ -1,5 +1,6 @@
 package org.commonwl.view.util;
 
 public class LicenseUtils {
-  public static final String SPDX_PREFIX = "https://spdx.org/licenses/";
+  public static final String SPDX_LICENSES_PREFIX = "https://spdx.org/licenses/";
+  public static final String SPDX_LICENSES_JSON_URL = SPDX_LICENSES_PREFIX + "licenses.json";
 }

--- a/src/main/java/org/commonwl/view/workflow/Workflow.java
+++ b/src/main/java/org/commonwl/view/workflow/Workflow.java
@@ -22,6 +22,7 @@ package org.commonwl.view.workflow;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.github.tbouron.SpdxLicense;
 import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
@@ -34,8 +35,6 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Table;
-
-import com.github.tbouron.SpdxLicense;
 import org.commonwl.view.WebConfig;
 import org.commonwl.view.WebConfig.Format;
 import org.commonwl.view.cwl.CWLElement;
@@ -360,8 +359,8 @@ public class Workflow extends BaseEntity implements Serializable {
     if (licenseLink == null) {
       return null;
     }
-    if (licenseLink.startsWith(LicenseUtils.SPDX_PREFIX)) {
-      return SpdxLicense.fromId(licenseLink.replace(LicenseUtils.SPDX_PREFIX, "")).name;
+    if (licenseLink.startsWith(LicenseUtils.SPDX_LICENSES_PREFIX)) {
+      return SpdxLicense.fromId(licenseLink.replace(LicenseUtils.SPDX_LICENSES_PREFIX, "")).name;
     }
     return licenseLink;
   }

--- a/src/main/java/org/commonwl/view/workflow/Workflow.java
+++ b/src/main/java/org/commonwl/view/workflow/Workflow.java
@@ -34,12 +34,15 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Table;
+
+import com.github.tbouron.SpdxLicense;
 import org.commonwl.view.WebConfig;
 import org.commonwl.view.WebConfig.Format;
 import org.commonwl.view.cwl.CWLElement;
 import org.commonwl.view.cwl.CWLStep;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.util.BaseEntity;
+import org.commonwl.view.util.LicenseUtils;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -351,6 +354,16 @@ public class Workflow extends BaseEntity implements Serializable {
 
   public void setLicenseLink(String licenseLink) {
     this.licenseLink = licenseLink;
+  }
+
+  public String getLicenseName() {
+    if (licenseLink == null) {
+      return null;
+    }
+    if (licenseLink.startsWith(LicenseUtils.SPDX_PREFIX)) {
+      return SpdxLicense.fromId(licenseLink.replace(LicenseUtils.SPDX_PREFIX, "")).name;
+    }
+    return licenseLink;
   }
 
   @Override

--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -49,29 +49,29 @@
 digraph G {
     graph [
         bgcolor="#eeeeee"
-		color="black"
-		fontsize="10"
-		labeljust="left"
-		clusterrank="local"
-		ranksep="0.22"
-		nodesep="0.05"
-	];
+        color="black"
+        fontsize="10"
+        labeljust="left"
+        clusterrank="local"
+        ranksep="0.22"
+        nodesep="0.05"
+    ];
     node [
-	    fontname="Helvetica"
-		fontsize="10"
-		fontcolor="black"
-		shape="record"
-		height="0"
-		width="0"
-		color="black"
-		fillcolor="lightgoldenrodyellow"
-		style="filled"
+        fontname="Helvetica"
+        fontsize="10"
+        fontcolor="black"
+        shape="record"
+        height="0"
+        width="0"
+        color="black"
+        fillcolor="lightgoldenrodyellow"
+        style="filled"
     ];
     edge [
-		fontname="Helvetica"
-		fontsize="8"
-		fontcolor="black"
-		color="black"
+        fontname="Helvetica"
+        fontsize="8"
+        fontcolor="black"
+        color="black"
         arrowsize="0.7"
     ];
     subgraph cluster_inputs {
@@ -199,18 +199,18 @@ digraph G {
                 <img th:if="${workflow.dockerLink == 'true'}" id="dockerLogo" th:src="@{/img/Docker-logo.png}" src="../static/img/Docker-logo.png" alt="docker logo" />
             </div>
             <div th:if="${workflow.licenseLink != null}" class="alert alert-success" role="alert">
-            	<span class="hidden-xs">This workflow is Open Source and may be reused according to the terms of:</span>
-            	<a href="http://example.com/" th:href="@{${workflow.licenseLink}}" class="alert-link">
+                <span class="hidden-xs">This workflow is Open Source and may be reused according to the terms of:</span>
+                <a href="http://example.com/" th:href="@{${workflow.licenseLink}}" class="alert-link">
                     <div th:remove="tag" th:text="${workflow.getLicenseName()}">
                         http://example.com/LICENSE
                     </div>
-				</a>
-				<div class="hidden-xs"><small>Note that the <em>tools</em> invoked by the workflow may have separate licenses.</small></div>
-			</div>
-			<div th:unless="${workflow.licenseLink}" class="alert alert-warning" role="alert">
-				Unknown workflow license, check
-				<a th:href="@{${workflow.retrievedFrom.getUrl()}}" href="#" rel="noopener" target="_blank">source repository</a>.
-			</div>
+                </a>
+                <div class="hidden-xs"><small>Note that the <em>tools</em> invoked by the workflow may have separate licenses.</small></div>
+            </div>
+            <div th:unless="${workflow.licenseLink}" class="alert alert-warning" role="alert">
+                Unknown workflow license, check
+                <a th:href="@{${workflow.retrievedFrom.getUrl()}}" href="#" rel="noopener" target="_blank">source repository</a>.
+            </div>
             <h2>Inputs</h2>
             <div th:if="${workflow.inputs.isEmpty()}" class="alert alert-info">
                 <p>There are no inputs in this workflow</p>
@@ -248,10 +248,10 @@ digraph G {
                 <div class="table-responsive">
                     <table class="table table-striped table-hover steps">
                         <thead>
-	                        <th>ID</th>
-	                        <th>Runs</th>
-	                        <th>Label</th>
-	                        <th>Doc</th>
+                            <th>ID</th>
+                            <th>Runs</th>
+                            <th>Label</th>
+                            <th>Doc</th>
                         </thead>
                         <tbody>
                         <tr th:each="step : ${workflow.steps}" th:with="workflowURL=@{${workflow.retrievedFrom.getUrl()}}">
@@ -307,8 +307,8 @@ digraph G {
         </div>
     </div>
     <div class="row hidden-print">
-    	<div class="col-md-12 text-center" id="formats">
-    	   <span th:each="format : ${formats}">
+        <div class="col-md-12 text-center" id="formats">
+           <span th:each="format : ${formats}">
             <a th:id="|format-${format}|" role="button" class="btn btn-default btn-sm" th:href="${workflow.getPermalink(format.name())}" th:text="${format}"
                       href="#">html</a>
            </span>
@@ -316,7 +316,7 @@ digraph G {
     </div>
     <div class="visible-print-block">
       <address>Permalink:
-      	<code th:text="${workflow.permalink}">https://w3id.org/cwl/view/git/933bf2a1a1cce32d88f88f136275535da9df0954/workflows/larger/test-hello.cwl</code>
+        <code th:text="${workflow.permalink}">https://w3id.org/cwl/view/git/933bf2a1a1cce32d88f88f136275535da9df0954/workflows/larger/test-hello.cwl</code>
       </address>
     </div>
 </div>

--- a/src/main/resources/templates/workflow.html
+++ b/src/main/resources/templates/workflow.html
@@ -201,34 +201,9 @@ digraph G {
             <div th:if="${workflow.licenseLink != null}" class="alert alert-success" role="alert">
             	<span class="hidden-xs">This workflow is Open Source and may be reused according to the terms of:</span>
             	<a href="http://example.com/" th:href="@{${workflow.licenseLink}}" class="alert-link">
-        						<span th:remove="tag" th:switch="${workflow.licenseLink}">
-        							<!-- TODO: Move license 'registry' to controller? -->
-        							<span th:remove="tag" th:case="'https://www.apache.org/licenses/LICENSE-2.0'">
-        								Apache License, version 2.0
-        							</span>
-        							<span th:remove="tag" th:case="'http://www.apache.org/licenses/LICENSE-2.0'">
-        								Apache License, version 2.0
-        							</span>
-        							<span th:remove="tag" th:case="'https://spdx.org/licenses/Apache-2.0'">
-        								Apache License, version 2.0
-        							</span>
-        							<span th:remove="tag" th:case="'https://mit-license.org/'">
-        								MIT License
-        							</span>
-        							<span th:remove="tag" th:case="'https://spdx.org/licenses/AGPL-3.0'">
-        								GNU Affero General Public License v3.0
-        							</span>
-        							<span th:remove="tag" th:case="'http://www.gnu.org/licenses/agpl.txt'">
-        								GNU Affero General Public License
-        							</span>
-        							<span th:remove="tag" th:case="'http://www.opensource.org/licenses/AGPL-3.0'">
-        								GNU Affero General Public License v3.0
-        							</span>
-									<div th:remove="tag" th:case="*" th:text="${workflow.licenseLink}">
-        								<!--  FIXME: This may not be an open source license! -->
-										http://example.com/LICENSE
-        							</div>
-        						</span>
+                    <div th:remove="tag" th:text="${workflow.getLicenseName()}">
+                        http://example.com/LICENSE
+                    </div>
 				</a>
 				<div class="hidden-xs"><small>Note that the <em>tools</em> invoked by the workflow may have separate licenses.</small></div>
 			</div>

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -43,6 +43,7 @@ import org.apache.jena.query.ResultSet;
 import org.apache.jena.query.ResultSetFactory;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
+import org.commonwl.view.git.GitConfig;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.workflow.Workflow;
 import org.commonwl.view.workflow.WorkflowOverview;
@@ -52,7 +53,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.springframework.test.context.ContextConfiguration;
 
+@ContextConfiguration(classes = {GitConfig.class})
 public class CWLServiceTest {
 
   /** RDFService for testing */
@@ -88,7 +91,12 @@ public class CWLServiceTest {
 
   @Test
   public void parsePackedWorkflowNativePath() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService,
+            Mockito.mock(CWLTool.class),
+            Mockito.mock(GitConfig.class).licenseVocab(),
+            5242880);
     Workflow dna =
         cwlService.parseWorkflowNative(
             Paths.get("src/test/resources/cwl/make_to_cwl/dna.cwl"), "main");
@@ -101,7 +109,12 @@ public class CWLServiceTest {
 
   @Test
   public void parsePackedWorkflowNativeStream() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService,
+            Mockito.mock(CWLTool.class),
+            Mockito.mock(GitConfig.class).licenseVocab(),
+            5242880);
     Workflow dna =
         cwlService.parseWorkflowNative(
             getClass().getResourceAsStream("/cwl/make_to_cwl/dna.cwl"), "main", "dna.cwl");
@@ -115,7 +128,12 @@ public class CWLServiceTest {
   /** Test native loading parsing of a the LobSTR workflow CWL version draft-3 */
   @Test
   public void parseLobSTRDraft3WorkflowNative() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService,
+            Mockito.mock(CWLTool.class),
+            Mockito.mock(GitConfig.class).licenseVocab(),
+            5242880);
     Workflow lobSTRDraft3 =
         cwlService.parseWorkflowNative(
             Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
@@ -125,7 +143,9 @@ public class CWLServiceTest {
   /** Test native loading parsing of a the LobSTR workflow CWL version 1.0 */
   @Test
   public void parseLobSTRv1WorkflowNative() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService, new CWLTool(), Mockito.mock(GitConfig.class).licenseVocab(), 5242880);
     Workflow lobSTRv1 =
         cwlService.parseWorkflowNative(
             Paths.get("src/test/resources/cwl/lobstr-v1/lobSTR-workflow.cwl"), null);
@@ -135,7 +155,9 @@ public class CWLServiceTest {
   /** Test native loading parsing of optional inline types */
   @Test
   public void parseWorkflowInlineOptionalTypesNative() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService, new CWLTool(), Mockito.mock(GitConfig.class).licenseVocab(), 5242880);
     //        URI uri = new
     // URI("https://github.com/emo-bon/pipeline-v5/raw/develop/workflows/gos_wf.cwl");
     //        InputStream is = uri.toURL().openStream();
@@ -154,7 +176,9 @@ public class CWLServiceTest {
   /** Test native loading parsing of MultipleInputFeatureRequirement using workflows */
   @Test
   public void parseWorkflowMultiInboundLins() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService, new CWLTool(), Mockito.mock(GitConfig.class).licenseVocab(), 5242880);
     Workflow wkflow =
         cwlService.parseWorkflowNative(
             Paths.get("src/test/resources/cwl/complex-workflow/complex-workflow-1.cwl"), null);
@@ -169,7 +193,9 @@ public class CWLServiceTest {
   /** Test native loading parsing of nested array types */
   @Test
   public void parseWorkflowNestedArrayTypes() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService, new CWLTool(), Mockito.mock(GitConfig.class).licenseVocab(), 5242880);
     Workflow wkflow =
         cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/nested_array.cwl"), null);
     assertEquals(wkflow.getInputs().get("overlap_files").getType(), "File[][]");
@@ -181,7 +207,9 @@ public class CWLServiceTest {
   /** Test native loading parsing of inputs with null default values */
   @Test
   public void parseWorkflowDefaultNullTypes() throws Exception {
-    CWLService cwlService = new CWLService(rdfService, new CWLTool(), 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService, new CWLTool(), Mockito.mock(GitConfig.class).licenseVocab(), 5242880);
     Workflow wkflow =
         cwlService.parseWorkflowNative(Paths.get("src/test/resources/cwl/null_default.cwl"), null);
     assertEquals(wkflow.getInputs().get("overlap_files").getDefaultVal(), null);
@@ -199,7 +227,9 @@ public class CWLServiceTest {
     when(mockCwlTool.getRDF(any(String.class))).thenReturn(readFileToString(packedWorkflowRdf));
 
     // CWLService to test
-    CWLService cwlService = new CWLService(rdfService, mockCwlTool, 5242880);
+    CWLService cwlService =
+        new CWLService(
+            rdfService, mockCwlTool, Mockito.mock(GitConfig.class).licenseVocab(), 5242880);
 
     GitDetails gitInfo =
         new GitDetails(
@@ -236,7 +266,12 @@ public class CWLServiceTest {
         Assertions.assertThrows(
             IOException.class,
             () -> {
-              CWLService cwlService = new CWLService(rdfService, Mockito.mock(CWLTool.class), 0);
+              CWLService cwlService =
+                  new CWLService(
+                      rdfService,
+                      Mockito.mock(CWLTool.class),
+                      Mockito.mock(GitConfig.class).licenseVocab(),
+                      0);
               cwlService.parseWorkflowNative(
                   Paths.get("src/test/resources/cwl/lobstr-draft3/lobSTR-workflow.cwl"), null);
             });
@@ -251,7 +286,11 @@ public class CWLServiceTest {
 
     // Test cwl service
     CWLService cwlService =
-        new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 5242880);
+        new CWLService(
+            Mockito.mock(RDFService.class),
+            Mockito.mock(CWLTool.class),
+            Mockito.mock(GitConfig.class).licenseVocab(),
+            5242880);
 
     // Run workflow overview
     File helloWorkflow = new File("src/test/resources/cwl/hello/hello.cwl");
@@ -270,10 +309,15 @@ public class CWLServiceTest {
 
     // Test cwl service
     CWLService cwlService =
-        new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 5242880);
+        new CWLService(
+            Mockito.mock(RDFService.class),
+            Mockito.mock(CWLTool.class),
+            Mockito.mock(GitConfig.class).licenseVocab(),
+            5242880);
 
     // Run workflow overview
     File helloWorkflow = new File("src/test/resources/cwl/hello/hello_doclist.cwl");
+    System.out.println(cwlService.normaliseLicenseLink("http://asdasdasda"));
     WorkflowOverview hello = cwlService.getWorkflowOverview(helloWorkflow);
     assertNotNull(hello);
     assertEquals("Puts a message into a file using echo. Even more doc", hello.getDoc());
@@ -291,7 +335,11 @@ public class CWLServiceTest {
             IOException.class,
             () -> {
               CWLService cwlService =
-                  new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 0);
+                  new CWLService(
+                      Mockito.mock(RDFService.class),
+                      Mockito.mock(CWLTool.class),
+                      Mockito.mock(GitConfig.class).licenseVocab(),
+                      0);
               cwlService.getWorkflowOverview(helloWorkflow);
             });
     assertEquals(
@@ -308,7 +356,11 @@ public class CWLServiceTest {
   @Test
   public void workflowOverviewsFromPackedFile() throws Exception {
     CWLService cwlService =
-        new CWLService(Mockito.mock(RDFService.class), Mockito.mock(CWLTool.class), 5242880);
+        new CWLService(
+            Mockito.mock(RDFService.class),
+            Mockito.mock(CWLTool.class),
+            Mockito.mock(GitConfig.class).licenseVocab(),
+            5242880);
     File packedFile = new File("src/test/resources/cwl/make_to_cwl/dna.cwl");
     assertTrue(cwlService.isPacked(packedFile));
     List<WorkflowOverview> overviews = cwlService.getWorkflowOverviewsFromPacked(packedFile);

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -279,6 +279,7 @@ public class CWLServiceTest {
     File expectedDotCode = new File("src/test/resources/cwl/make_to_cwl/visualisation.dot");
     assertEquals(readFileToString(expectedDotCode), workflow.getVisualisationDot());
     assertEquals("https://spdx.org/licenses/Apache-2.0", workflow.getLicenseLink());
+    assertEquals("Apache License 2.0", workflow.getLicenseName());
   }
 
   /** Test IOException is thrown when files are over limit */


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit introduces 3 main improvements:
 - It moves the license dictionary from the frontend (Thymeleaf template) to the backend (Workflow class)
 - It groups licenses common links to the corresponding SPDX URIs
 - It translates SPDX URIs into licenses' common names for better visualization

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This PR ports the improvements introduced in #487 to the frontend.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/15560442/210182165-df4bc439-30c6-47a4-8e64-e3c2749cd408.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
