### PR TITLE
Remove temp repositories

### DIFF
--- a/src/main/java/org/commonwl/view/cwl/CWLToolRunner.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLToolRunner.java
@@ -171,6 +171,7 @@ public class CWLToolRunner {
       FileUtils.deleteGitRepository(repo);
     } finally {
       gitSemaphore.release(repoUrl);
+      FileUtils.deleteTemporaryGitRepository(repo);
       queuedWorkflowRepository.save(queuedWorkflow);
     }
   }

--- a/src/main/java/org/commonwl/view/git/GitService.java
+++ b/src/main/java/org/commonwl/view/git/GitService.java
@@ -19,8 +19,6 @@
 
 package org.commonwl.view.git;
 
-import static org.apache.jena.ext.com.google.common.io.Files.createTempDir;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -29,6 +27,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.UUID;
+
 import org.apache.commons.codec.digest.DigestUtils;
 import org.commonwl.view.researchobject.HashableAgent;
 import org.eclipse.jgit.api.Git;
@@ -52,10 +52,10 @@ public class GitService {
   private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   // Location to check out git repositories into
-  private Path gitStorage;
+  private final Path gitStorage;
 
   // Whether submodules are also cloned
-  private boolean cloneSubmodules;
+  private final boolean cloneSubmodules;
 
   @Autowired
   public GitService(
@@ -217,5 +217,11 @@ public class GitService {
         .setDirectory(directory)
         .setCloneAllBranches(true)
         .call();
+  }
+
+  protected File createTempDir() throws IOException {
+    Path repoDir = gitStorage.resolve(String.valueOf(UUID.randomUUID()));
+    Files.createDirectory(repoDir);
+    return repoDir.toFile();
   }
 }

--- a/src/main/java/org/commonwl/view/git/GitService.java
+++ b/src/main/java/org/commonwl/view/git/GitService.java
@@ -28,7 +28,6 @@ import java.nio.file.Path;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
-
 import org.apache.commons.codec.digest.DigestUtils;
 import org.commonwl.view.researchobject.HashableAgent;
 import org.eclipse.jgit.api.Git;

--- a/src/main/java/org/commonwl/view/util/FileUtils.java
+++ b/src/main/java/org/commonwl/view/util/FileUtils.java
@@ -3,6 +3,8 @@ package org.commonwl.view.util;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.regex.Pattern;
+
 import org.apache.taverna.robundle.Bundle;
 import org.apache.taverna.robundle.fs.BundleFileSystem;
 import org.eclipse.jgit.api.Git;
@@ -16,6 +18,9 @@ import org.eclipse.jgit.api.Git;
  * @since 1.4.6
  */
 public class FileUtils {
+
+  private static final Pattern UUID_REGEX_PATTERN =
+      Pattern.compile("^[{]?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}[}]?$");
 
   private FileUtils() {}
 
@@ -59,7 +64,7 @@ public class FileUtils {
    *
    * directory, which corresponds to the cloned folder with the source code from git. Since
    * temporary folders are generated using <code>UUID.randomUUID()</code> instead of the commit hex
-   * digest, if the folder name contains a '-' character it is identified as temporary.
+   * digest, if the folder name is a valid UUID it is identified as temporary.
    *
    * @param repo Git repository object
    * @throws IOException if it fails to delete the Git repository directory
@@ -69,9 +74,11 @@ public class FileUtils {
     if (repo != null
         && repo.getRepository() != null
         && repo.getRepository().getDirectory() != null
-        && repo.getRepository().getDirectory().getParentFile() != null
-        && repo.getRepository().getDirectory().getParentFile().getName().contains("-")) {
-      deleteGitRepository(repo);
+        && repo.getRepository().getDirectory().getParentFile() != null) {
+      if (UUID_REGEX_PATTERN.matcher(
+          repo.getRepository().getDirectory().getParentFile().getName()).matches()) {
+        deleteGitRepository(repo);
+      }
     }
   }
 

--- a/src/main/java/org/commonwl/view/util/FileUtils.java
+++ b/src/main/java/org/commonwl/view/util/FileUtils.java
@@ -48,6 +48,34 @@ public class FileUtils {
   }
 
   /**
+   * Deletes the directory of a temporary git repository. Note that the <code>Git</code> object contains a
+   * repository with a directory, but this directory points to the
+   *
+   * <pre>.git</pre>
+   *
+   * directory. This method will delete the parent of the
+   *
+   * <pre>.git</pre>
+   *
+   * directory, which corresponds to the cloned folder with the source code from git.
+   * Since temporary folders are generated using <code>UUID.randomUUID()</code> instead of the commit hex digest,
+   * if the fodler name contains a '-' character it is identified as temporary.
+   *
+   * @param repo Git repository object
+   * @throws IOException if it fails to delete the Git repository directory
+   * @since 1.4.6
+   */
+  public static void deleteTemporaryGitRepository(Git repo) throws IOException {
+    if (repo != null
+        && repo.getRepository() != null
+        && repo.getRepository().getDirectory() != null
+        && repo.getRepository().getDirectory().getParentFile() != null
+        && repo.getRepository().getDirectory().getParentFile().getName().contains("-")) {
+      deleteGitRepository(repo);
+    }
+  }
+
+  /**
    * Deletes the bundle temporary directory.
    *
    * <p>The <code>Bundle</code> object is an Apache Taverna object. Be careful as it acts as a

--- a/src/main/java/org/commonwl/view/util/FileUtils.java
+++ b/src/main/java/org/commonwl/view/util/FileUtils.java
@@ -48,8 +48,8 @@ public class FileUtils {
   }
 
   /**
-   * Deletes the directory of a temporary git repository. Note that the <code>Git</code> object contains a
-   * repository with a directory, but this directory points to the
+   * Deletes the directory of a temporary git repository. Note that the <code>Git</code> object
+   * contains a repository with a directory, but this directory points to the
    *
    * <pre>.git</pre>
    *
@@ -57,9 +57,9 @@ public class FileUtils {
    *
    * <pre>.git</pre>
    *
-   * directory, which corresponds to the cloned folder with the source code from git.
-   * Since temporary folders are generated using <code>UUID.randomUUID()</code> instead of the commit hex digest,
-   * if the fodler name contains a '-' character it is identified as temporary.
+   * directory, which corresponds to the cloned folder with the source code from git. Since
+   * temporary folders are generated using <code>UUID.randomUUID()</code> instead of the commit hex
+   * digest, if the folder name contains a '-' character it is identified as temporary.
    *
    * @param repo Git repository object
    * @throws IOException if it fails to delete the Git repository directory

--- a/src/test/java/org/commonwl/view/git/GitServiceTest.java
+++ b/src/test/java/org/commonwl/view/git/GitServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import org.eclipse.jgit.api.CheckoutCommand;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -53,7 +54,7 @@ public class GitServiceTest {
 
   @BeforeEach
   public void setup() throws GitAPIException {
-    GitService gitService = new GitService(null, false);
+    GitService gitService = new GitService(Path.of(System.getProperty("java.io.tmpdir")), false);
     this.spyGitService = spy(gitService);
     this.mockGit = mock(Git.class);
     this.mockGoodCheckoutCommand = mock(CheckoutCommand.class);

--- a/src/test/java/org/commonwl/view/util/FileUtilsTest.java
+++ b/src/test/java/org/commonwl/view/util/FileUtilsTest.java
@@ -8,9 +8,13 @@ import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.UUID;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.taverna.robundle.Bundle;
 import org.apache.taverna.robundle.fs.BundleFileSystem;
+import org.commonwl.view.git.GitDetails;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.lib.Repository;
 import org.junit.Rule;
@@ -249,5 +253,34 @@ public class FileUtilsTest {
     assertTrue(bundleTemporaryDirectory.getParentFile().exists());
     FileUtils.deleteBundleParentDirectory(bundle);
     assertFalse(bundleTemporaryDirectory.exists());
+  }
+
+  @Test
+  public void testRemoveTemporaryRepository() throws IOException {
+    Git tempRepository = mock(Git.class);
+    Repository tempRepository1 = mock(Repository.class);
+    when(tempRepository.getRepository()).thenReturn(tempRepository1);
+    File tempGitRepositoryParent = temporaryFolder.newFolder(String.valueOf(UUID.randomUUID()));
+    File tempGitRepository = tempGitRepositoryParent.toPath().resolve(".git").toFile();
+    Files.createDirectory(tempGitRepository.toPath());
+    when(tempRepository1.getDirectory()).thenReturn(tempGitRepository);
+    assertTrue(tempGitRepository.exists());
+    FileUtils.deleteTemporaryGitRepository(tempRepository);
+    assertFalse(tempGitRepository.exists());
+
+    Git notTempRepository = mock(Git.class);
+    Repository notTempRepository1 = mock(Repository.class);
+    when(notTempRepository.getRepository()).thenReturn(notTempRepository1);
+    File notTempGitRepositoryParent =
+        temporaryFolder.newFolder(
+            DigestUtils.sha1Hex(
+                GitDetails.normaliseUrl(
+                    "https://github.com/common-workflow-language/cwlviewer.git")));
+    File notTempGitRepository = notTempGitRepositoryParent.toPath().resolve(".git").toFile();
+    Files.createDirectory(notTempGitRepository.toPath());
+    when(notTempRepository1.getDirectory()).thenReturn(notTempGitRepository);
+    assertTrue(notTempGitRepository.exists());
+    FileUtils.deleteTemporaryGitRepository(notTempRepository);
+    assertTrue(notTempGitRepository.exists());
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This commit prevents `/tmp` folder from growing indefinitely large by implementing two fixes to the git repo conflict management logic:
 
- When a conflict is detected, the git repository is cloned on a
       temporary folder directly on the `gitStorage` fs (not in the system
       `/tmp` directory). This prevents using Docker's ephemeral fs under
       the hood.
 - A temporary repository is deleted as soon as the invoking method
       releases the git semaphore. This makes sense because the primary copy
       of each repository will still be preserved in cache.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Avoid saturating Docker file-system during bulk import operations.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
