### PR TITLE
better handle IOExceptions when scanning an entire directory

### DIFF
--- a/src/main/java/org/commonwl/view/workflow/WorkflowService.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowService.java
@@ -250,9 +250,13 @@ public class WorkflowService {
           if (eIndex > 0) {
             String extension = file.getName().substring(eIndex);
             if (extension.equals("cwl")) {
-              WorkflowOverview overview = cwlService.getWorkflowOverview(file);
-              if (overview != null) {
-                workflowsInDir.add(overview);
+              try {
+                WorkflowOverview overview = cwlService.getWorkflowOverview(file);
+                if (overview != null) {
+                  workflowsInDir.add(overview);
+                }
+              } catch (IOException err) {
+                logger.error("Skipping file due to IOException: " + file.toString(), err);
               }
             }
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
When scanning an entire directory, a single IOException (like a malformed YAML document) will return no results, instead of skipping that one workflow

For example: https://github.com/hybridstat/elixir-gr-project/tree/dc1b566523dc4d6f65032d40f8d4e716d7cb339f/CWL/workflows

Gives

> Whoops - Something Went Wrong!
> Error: An internal server error occurred 

Instead of skipping https://github.com/hybridstat/elixir-gr-project/blob/dc1b566523dc4d6f65032d40f8d4e716d7cb339f/CWL/workflows/mapping-se-qc-r.cwl#L44 due to the missing `:`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
