### PR TITLE
allow some CWL extensions that we know about

### DIFF
--- a/src/main/java/org/commonwl/view/cwl/CWLTool.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLTool.java
@@ -107,6 +107,8 @@ public class CWLTool {
         "--disable-color",
         "--non-strict",
         "--quiet",
+        "--enable-dev",
+        "--enable-ext",
         "--skip-schemas",
         argument,
         workflowUrl

--- a/src/main/java/org/commonwl/view/git/GitConfig.java
+++ b/src/main/java/org/commonwl/view/git/GitConfig.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.apache.commons.lang3.StringUtils;
 import org.commonwl.view.util.LicenseUtils;
 import org.springframework.context.annotation.Bean;
@@ -24,7 +23,7 @@ public class GitConfig {
         restTemplate.getForObject(LicenseUtils.SPDX_LICENSES_JSON_URL, ObjectNode.class);
     if (jsonLicenses == null) {
       throw new GitLicenseException(
-              "Failed to load SPDX licenses from " + LicenseUtils.SPDX_LICENSES_JSON_URL);
+          "Failed to load SPDX licenses from " + LicenseUtils.SPDX_LICENSES_JSON_URL);
     }
     Map<String, String> licenseMap = new HashMap<>();
     for (JsonNode license : jsonLicenses.withArray("licenses")) {

--- a/src/main/java/org/commonwl/view/util/FileUtils.java
+++ b/src/main/java/org/commonwl/view/util/FileUtils.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.regex.Pattern;
-
 import org.apache.taverna.robundle.Bundle;
 import org.apache.taverna.robundle.fs.BundleFileSystem;
 import org.eclipse.jgit.api.Git;
@@ -75,8 +74,9 @@ public class FileUtils {
         && repo.getRepository() != null
         && repo.getRepository().getDirectory() != null
         && repo.getRepository().getDirectory().getParentFile() != null) {
-      if (UUID_REGEX_PATTERN.matcher(
-          repo.getRepository().getDirectory().getParentFile().getName()).matches()) {
+      if (UUID_REGEX_PATTERN
+          .matcher(repo.getRepository().getDirectory().getParentFile().getName())
+          .matches()) {
         deleteGitRepository(repo);
       }
     }

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -19,6 +19,20 @@
 
 package org.commonwl.view.cwl;
 
+import static org.apache.commons.io.FileUtils.readFileToString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.DatasetFactory;
 import org.apache.jena.query.Query;
@@ -42,21 +56,6 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.springframework.test.context.ContextConfiguration;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Paths;
-import java.util.List;
-import java.util.Map;
-
-import static org.apache.commons.io.FileUtils.readFileToString;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 @ContextConfiguration(classes = {GitConfig.class})
 public class CWLServiceTest {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Pass `--enable-ext` and `--enable-dev` when running cwltool on user-supplied workflows.

## Motivation and Context
Otherwise some workflows won't parse, like https://gitlab.ebrains.eu/weidler/sc5-cwl-workflow/-/blob/872880d684193c5e936c76dff3ebf77d2e3e5f59/workflow.cwl


## How Has This Been Tested?
Tested locally using the workflow above

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/1330696/214663053-ebb4676e-b614-4253-ac09-915d9e519cc2.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
