### PR TITLE
error improvements

### DIFF
--- a/src/main/java/org/commonwl/view/cwl/CWLNotAWorkflowException.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLNotAWorkflowException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.commonwl.view.cwl;
+
+/** Exception thrown when the provided CWL document is not a Workflow. */
+public class CWLNotAWorkflowException extends CWLValidationException {
+
+  public CWLNotAWorkflowException(String message) {
+    super(message);
+  }
+
+  public CWLNotAWorkflowException(Throwable throwable) {
+    super(throwable);
+  }
+
+  public CWLNotAWorkflowException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+}

--- a/src/main/java/org/commonwl/view/cwl/CWLService.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLService.java
@@ -181,7 +181,8 @@ public class CWLService {
    * @return The constructed workflow object
    */
   public Workflow parseWorkflowNative(
-      InputStream workflowStream, String packedWorkflowId, String defaultLabel) throws IOException {
+      InputStream workflowStream, String packedWorkflowId, String defaultLabel)
+      throws IOException, WorkflowNotFoundException, CWLValidationException {
     // Parse file as yaml
     Map<String, Object> cwlFile = yamlStreamToJson(workflowStream);
 
@@ -205,9 +206,11 @@ public class CWLService {
       }
       if (!found && !packedWorkflowId.isEmpty()) throw new WorkflowNotFoundException();
     }
-    if (!found && extractProcess(cwlFile) == CWLProcess.WORKFLOW) {
-      // Check the current json node is a workflow
+    if (!found && (extractProcess(cwlFile) == CWLProcess.WORKFLOW)) {
       found = true;
+    } else if (found && (extractProcess(cwlFile) != CWLProcess.WORKFLOW)) {
+      throw new CWLNotAWorkflowException(
+          "Not a 'class: Workflow' CWL document, is a " + extractProcess(cwlFile));
     }
     if (!found) {
       throw new WorkflowNotFoundException();
@@ -248,7 +251,7 @@ public class CWLService {
    * @return The constructed workflow object
    */
   public Workflow parseWorkflowNative(Path workflowFile, String packedWorkflowId)
-      throws IOException {
+      throws IOException, WorkflowNotFoundException, CWLValidationException {
 
     // Check file size limit before parsing
     long fileSizeBytes = Files.size(workflowFile);

--- a/src/main/java/org/commonwl/view/cwl/CWLService.java
+++ b/src/main/java/org/commonwl/view/cwl/CWLService.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringWriter;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -128,7 +129,7 @@ public class CWLService {
     if (workflowFile.length() > singleFileSizeLimit) {
       return false;
     }
-    String fileContent = readFileToString(workflowFile);
+    String fileContent = readFileToString(workflowFile, StandardCharsets.UTF_8);
     return fileContent.contains("$graph");
   }
 

--- a/src/main/java/org/commonwl/view/git/GitService.java
+++ b/src/main/java/org/commonwl/view/git/GitService.java
@@ -38,8 +38,6 @@ import org.eclipse.jgit.errors.RepositoryNotFoundException;
 import org.eclipse.jgit.lib.ObjectId;
 import org.eclipse.jgit.lib.PersonIdent;
 import org.eclipse.jgit.revwalk.RevCommit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -47,8 +45,6 @@ import org.springframework.stereotype.Service;
 /** Handles Git related functionality */
 @Service
 public class GitService {
-
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   // Location to check out git repositories into
   private final Path gitStorage;

--- a/src/main/java/org/commonwl/view/workflow/WorkflowController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowController.java
@@ -30,8 +30,10 @@ import java.security.NoSuchAlgorithmException;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.commonwl.view.WebConfig;
+import org.commonwl.view.cwl.CWLNotAWorkflowException;
 import org.commonwl.view.cwl.CWLService;
 import org.commonwl.view.cwl.CWLToolStatus;
+import org.commonwl.view.cwl.CWLValidationException;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.graphviz.GraphVizService;
 import org.eclipse.jgit.api.errors.GitAPIException;
@@ -162,6 +164,10 @@ public class WorkflowController {
         } catch (WorkflowNotFoundException ex) {
           logger.warn("git.notFound " + workflowForm, ex);
           bindingResult.rejectValue("url", "git.notFound");
+          return new ModelAndView("index");
+        } catch (CWLNotAWorkflowException ex) {
+          logger.warn("cwl.notAWorkflow " + workflowForm, ex);
+          bindingResult.rejectValue("url", "cwl.notAWorkflow");
           return new ModelAndView("index");
         } catch (Exception ex) {
           logger.warn("url.parsingError " + workflowForm, ex);
@@ -629,7 +635,11 @@ public class WorkflowController {
           } catch (WorkflowNotFoundException ex) {
             logger.warn("git.notFound " + workflowForm, ex);
             errors.rejectValue(
-                "url", "git.notFound", "The workflow could not be found within the repository");
+                "url", "git.notFound", "The workflow could not be found within the repository.");
+          } catch (CWLValidationException ex) {
+            logger.warn("cwl.invalid " + workflowForm, ex);
+            errors.rejectValue(
+                "url", "cwl.invalid", "The workflow had a parsing error: " + ex.getMessage());
           } catch (IOException ex) {
             logger.warn("url.parsingError " + workflowForm, ex);
             errors.rejectValue(
@@ -658,7 +668,8 @@ public class WorkflowController {
     }
   }
 
-  private Resource getGraphFromInputStream(InputStream in, String format) throws IOException {
+  private Resource getGraphFromInputStream(InputStream in, String format)
+      throws IOException, WorkflowNotFoundException, CWLValidationException {
     Workflow workflow =
         cwlService.parseWorkflowNative(in, null, "workflow"); // first workflow will do
     InputStream out = graphVizService.getGraphStream(workflow.getVisualisationDot(), format);

--- a/src/main/java/org/commonwl/view/workflow/WorkflowFormValidator.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowFormValidator.java
@@ -23,8 +23,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.commonwl.view.git.GitDetails;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.validation.Errors;
 import org.springframework.validation.ValidationUtils;
@@ -32,8 +30,6 @@ import org.springframework.validation.ValidationUtils;
 /** Runs validation on the workflow form from the main page */
 @Component
 public class WorkflowFormValidator {
-
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   // URL validation for cwl files on github.com
   private static final String GITHUB_CWL_REGEX =

--- a/src/main/java/org/commonwl/view/workflow/WorkflowJSONController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowJSONController.java
@@ -26,8 +26,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.util.*;
 import org.commonwl.view.cwl.CWLValidationException;
 import org.commonwl.view.git.GitDetails;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -43,8 +41,6 @@ import org.springframework.web.servlet.HandlerMapping;
 /** JSON API Controller */
 @RestController
 public class WorkflowJSONController {
-
-  private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
   private final WorkflowFormValidator workflowFormValidator;
   private final WorkflowService workflowService;
@@ -67,7 +63,7 @@ public class WorkflowJSONController {
    *
    * @return A list of all the workflows
    */
-  @GetMapping(value = "/workflows", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(value = "/workflows", produces = MediaType.APPLICATION_JSON_VALUE)
   public Page<Workflow> listWorkflowsJson(
       Model model, @PageableDefault(size = 10) Pageable pageable) {
     return workflowService.getPageOfWorkflows(pageable);
@@ -81,7 +77,7 @@ public class WorkflowJSONController {
   @GetMapping(
       value = "/workflows",
       params = "search",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+      produces = MediaType.APPLICATION_JSON_VALUE)
   public Page<Workflow> searchWorkflowsJson(
       Model model,
       @PageableDefault(size = 10) Pageable pageable,
@@ -98,7 +94,7 @@ public class WorkflowJSONController {
    * @param packedId The ID of the workflow if the file is packed
    * @return Appropriate response code and optional JSON string with message
    */
-  @PostMapping(value = "/workflows", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @PostMapping(value = "/workflows", produces = MediaType.APPLICATION_JSON_VALUE)
   public ResponseEntity<?> newWorkflowFromGitURLJson(
       @RequestParam(value = "url") String url,
       @RequestParam(value = "branch", required = false) String branch,
@@ -119,7 +115,7 @@ public class WorkflowJSONController {
         error = "Could not parse workflow details from URL";
       }
       Map<String, String> message = Collections.singletonMap("message", "Error: " + error);
-      return new ResponseEntity<Map>(message, HttpStatus.BAD_REQUEST);
+      return new ResponseEntity<Map<String, String>>(message, HttpStatus.BAD_REQUEST);
     } else {
       // Get workflow or create if does not exist
       Workflow workflow = workflowService.getWorkflow(gitInfo);
@@ -139,7 +135,6 @@ public class WorkflowJSONController {
                 }
               } else {
                 // Error with alternatives suggested
-                List<WorkflowOverview> test = queued.getWorkflowList();
                 List<String> workflowUris = new ArrayList<>();
                 for (WorkflowOverview overview : queued.getWorkflowList()) {
                   workflowUris.add(overview.getFileName().substring(1));
@@ -150,18 +145,19 @@ public class WorkflowJSONController {
                     "This workflow file is packed and contains multiple workflow "
                         + "descriptions. Please provide a packedId parameter with one of the following");
                 responseMap.put("packedId", workflowUris);
-                return new ResponseEntity<Map>(responseMap, HttpStatus.UNPROCESSABLE_ENTITY);
+                return new ResponseEntity<Map<String, Object>>(
+                    responseMap, HttpStatus.UNPROCESSABLE_ENTITY);
               }
             }
           } catch (CWLValidationException ex) {
             Map<String, String> message =
                 Collections.singletonMap("message", "Error:" + ex.getMessage());
-            return new ResponseEntity<Map>(message, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<Map<String, String>>(message, HttpStatus.BAD_REQUEST);
           } catch (Exception ex) {
             Map<String, String> message =
                 Collections.singletonMap(
                     "message", "Error: Workflow could not be created from the provided cwl file");
-            return new ResponseEntity<Map>(message, HttpStatus.BAD_REQUEST);
+            return new ResponseEntity<Map<String, String>>(message, HttpStatus.BAD_REQUEST);
           }
         }
         response.setHeader("Location", "/queue/" + queued.getId());
@@ -190,7 +186,7 @@ public class WorkflowJSONController {
         "/workflows/{domain}.com/{owner}/{repoName}/tree/{branch}/**",
         "/workflows/{domain}.com/{owner}/{repoName}/blob/{branch}/**"
       },
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+      produces = MediaType.APPLICATION_JSON_VALUE)
   public Workflow getWorkflowJson(
       @PathVariable("domain") String domain,
       @PathVariable("owner") String owner,
@@ -222,7 +218,7 @@ public class WorkflowJSONController {
    */
   @GetMapping(
       value = "/workflows/*/*.git/{branch}/**",
-      produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+      produces = MediaType.APPLICATION_JSON_VALUE)
   public Workflow getWorkflowJsonGeneric(
       @PathVariable("branch") String branch, HttpServletRequest request) {
     // The wildcard end of the URL is the path
@@ -248,7 +244,7 @@ public class WorkflowJSONController {
    * @return 303 see other status w/ location header if success, otherwise JSON representation of
    *     object
    */
-  @GetMapping(value = "/queue/{queueID}", produces = MediaType.APPLICATION_JSON_UTF8_VALUE)
+  @GetMapping(value = "/queue/{queueID}", produces = MediaType.APPLICATION_JSON_VALUE)
   public QueuedWorkflow checkQueueJson(
       @PathVariable("queueID") String queueID, HttpServletResponse response) {
     QueuedWorkflow queuedWorkflow = workflowService.getQueuedWorkflow(queueID);

--- a/src/main/java/org/commonwl/view/workflow/WorkflowPermalinkController.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowPermalinkController.java
@@ -87,7 +87,7 @@ public class WorkflowPermalinkController {
       produces = {
         MediaType.TEXT_HTML_VALUE,
         MediaType.APPLICATION_JSON_VALUE,
-        MediaType.APPLICATION_JSON_UTF8_VALUE
+        MediaType.APPLICATION_JSON_VALUE
       })
   public void goToViewer(
       @PathVariable("commitid") String commitId,

--- a/src/main/java/org/commonwl/view/workflow/WorkflowService.java
+++ b/src/main/java/org/commonwl/view/workflow/WorkflowService.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import org.commonwl.view.cwl.CWLService;
 import org.commonwl.view.cwl.CWLToolRunner;
 import org.commonwl.view.cwl.CWLToolStatus;
+import org.commonwl.view.cwl.CWLValidationException;
 import org.commonwl.view.git.GitDetails;
 import org.commonwl.view.git.GitSemaphore;
 import org.commonwl.view.git.GitService;
@@ -308,7 +309,7 @@ public class WorkflowService {
    * @throws IOException Other file handling exceptions
    */
   public QueuedWorkflow createQueuedWorkflow(GitDetails gitInfo)
-      throws GitAPIException, WorkflowNotFoundException, IOException {
+      throws GitAPIException, WorkflowNotFoundException, IOException, CWLValidationException {
     QueuedWorkflow queuedWorkflow;
 
     Git repo = null;
@@ -338,7 +339,7 @@ public class WorkflowService {
 
       // Check workflow is readable
       if (!Files.isReadable(workflowFile)) {
-        throw new WorkflowNotFoundException();
+        throw new WorkflowNotFoundException("Unable to read workflow file on disk.");
       }
 
       // Handling of packed workflows

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -6,5 +6,8 @@ git.retrievalError = The workflow could not be retrieved from the Git repository
 git.notFound = The workflow could not be found within the repository
 git.sshError = SSH URLs are not supported, please provide a HTTPS URL for the repository or submodules
 
+cwl.invalid = An error with the CWL workflow itself
+cwl.notAWorkflow = The provided CWL document is not a "class: Workflow" file.
+
 url.parsingError = An unexpected error occurred when parsing the workflow
 url.noWorkflowsInDirectory = No workflow files were found in the given directory

--- a/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
+++ b/src/test/java/org/commonwl/view/cwl/CWLServiceTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -70,7 +71,10 @@ public class CWLServiceTest {
     File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
     Model workflowModel = ModelFactory.createDefaultModel();
     workflowModel.read(
-        new ByteArrayInputStream(readFileToString(packedWorkflowRdf).getBytes()), null, "TURTLE");
+        new ByteArrayInputStream(
+            readFileToString(packedWorkflowRdf, StandardCharsets.UTF_8).getBytes()),
+        null,
+        "TURTLE");
     Dataset workflowDataset = DatasetFactory.create();
     workflowDataset.addNamedModel(
         "https://w3id.org/cwl/view/git/549c973ccc01781595ce562dea4cedc6c9540fe0/workflows/make-to-cwl/dna.cwl#main",
@@ -235,7 +239,8 @@ public class CWLServiceTest {
     // Mock CWLTool
     CWLTool mockCwlTool = Mockito.mock(CWLTool.class);
     File packedWorkflowRdf = new File("src/test/resources/cwl/make_to_cwl/dna.ttl");
-    when(mockCwlTool.getRDF(any(String.class))).thenReturn(readFileToString(packedWorkflowRdf));
+    when(mockCwlTool.getRDF(any(String.class)))
+        .thenReturn(readFileToString(packedWorkflowRdf, StandardCharsets.UTF_8));
 
     // CWLService to test
     CWLService cwlService =
@@ -264,7 +269,8 @@ public class CWLServiceTest {
     assertEquals(1, workflow.getOutputs().size());
     assertEquals(3, workflow.getSteps().size());
     File expectedDotCode = new File("src/test/resources/cwl/make_to_cwl/visualisation.dot");
-    assertEquals(readFileToString(expectedDotCode), workflow.getVisualisationDot());
+    assertEquals(
+        readFileToString(expectedDotCode, StandardCharsets.UTF_8), workflow.getVisualisationDot());
     assertEquals("https://spdx.org/licenses/Apache-2.0", workflow.getLicenseLink());
     assertEquals("Apache License 2.0", workflow.getLicenseName());
   }

--- a/src/test/java/org/commonwl/view/graphviz/ModelDotWriterTest.java
+++ b/src/test/java/org/commonwl/view/graphviz/ModelDotWriterTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
 import java.io.StringWriter;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -104,6 +104,6 @@ public class ModelDotWriterTest {
 
     File expectedDot = new File("src/test/resources/graphviz/testWorkflow.dot");
     assertEquals(
-        FileUtils.readFileToString(expectedDot, Charset.defaultCharset()), dotSource.toString());
+        FileUtils.readFileToString(expectedDot, StandardCharsets.UTF_8), dotSource.toString());
   }
 }

--- a/src/test/java/org/commonwl/view/workflow/WorkflowJSONControllerTest.java
+++ b/src/test/java/org/commonwl/view/workflow/WorkflowJSONControllerTest.java
@@ -91,10 +91,9 @@ public class WorkflowJSONControllerTest {
 
     // Error in validation
     mockMvc
-        .perform(
-            post("/workflows").param("url", "invalidurl").accept(MediaType.APPLICATION_JSON_UTF8))
+        .perform(post("/workflows").param("url", "invalidurl").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.message", is("Error: Could not parse workflow details from URL")));
 
     // Workflow already exists
@@ -102,7 +101,7 @@ public class WorkflowJSONControllerTest {
         .perform(
             post("/workflows")
                 .param("url", "https://github.com/owner/repoName/tree/branch/path/workflow.cwl")
-                .accept(MediaType.APPLICATION_JSON_UTF8))
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isSeeOther())
         .andExpect(
             header()
@@ -115,7 +114,7 @@ public class WorkflowJSONControllerTest {
         .perform(
             post("/workflows")
                 .param("url", "https://github.com/owner/repoName/tree/branch/path/workflow.cwl")
-                .accept(MediaType.APPLICATION_JSON_UTF8))
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest());
 
     // Success
@@ -123,7 +122,7 @@ public class WorkflowJSONControllerTest {
         .perform(
             post("/workflows")
                 .param("url", "https://github.com/owner/repoName/tree/branch/path/success.cwl")
-                .accept(MediaType.APPLICATION_JSON_UTF8))
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isAccepted())
         .andExpect(header().string("Location", is("/queue/123")));
 
@@ -132,7 +131,7 @@ public class WorkflowJSONControllerTest {
         .perform(
             post("/workflows")
                 .param("url", "https://github.com/owner/repoName/tree/branch/path/singlePacked.cwl")
-                .accept(MediaType.APPLICATION_JSON_UTF8))
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isAccepted())
         .andExpect(header().string("Location", is("/queue/123")));
 
@@ -142,7 +141,7 @@ public class WorkflowJSONControllerTest {
             post("/workflows")
                 .param(
                     "url", "https://github.com/owner/repoName/tree/branch/path/multiplePacked.cwl")
-                .accept(MediaType.APPLICATION_JSON_UTF8))
+                .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isUnprocessableEntity())
         .andExpect(
             jsonPath(
@@ -174,7 +173,7 @@ public class WorkflowJSONControllerTest {
             get("/workflows/github.com/owner/repo/blob/branch/path/to/workflow.cwl")
                 .accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.retrievedFrom.repoUrl", is("https://github.com/owner/repo.git")))
         .andExpect(jsonPath("$.retrievedFrom.branch", is("branch")))
         .andExpect(jsonPath("$.retrievedFrom.path", is("path/to/workflow.cwl")))
@@ -224,29 +223,29 @@ public class WorkflowJSONControllerTest {
 
     // No workflow
     mockMvc
-        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON_UTF8))
+        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isNotFound());
 
     // Running workflow
     mockMvc
-        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON_UTF8))
+        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.cwltoolStatus", is("RUNNING")))
         .andExpect(jsonPath("$.cwltoolVersion", is("v1.0")));
 
     // Error workflow
     mockMvc
-        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON_UTF8))
+        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isOk())
-        .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8))
+        .andExpect(content().contentType(MediaType.APPLICATION_JSON))
         .andExpect(jsonPath("$.cwltoolStatus", is("ERROR")))
         .andExpect(jsonPath("$.message", is("cwltool error message")))
         .andExpect(jsonPath("$.cwltoolVersion", is("v1.0")));
 
     // Success workflow
     mockMvc
-        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON_UTF8))
+        .perform(get("/queue/123").accept(MediaType.APPLICATION_JSON))
         .andExpect(status().isSeeOther())
         .andExpect(
             header()


### PR DESCRIPTION
- address some deprecations
- detect non-Workflow CWL documents and give a better error message


## Description
When the use provides a path to a CWL document that is not `class: Workflow` or a `$graph` containing a `class: Workflow`, we need a better error message than `Error: The workflow could not be found within the repository`


## Motivation and Context
Fixes #582 

## How Has This Been Tested?
I tested locally with the provided Git repository URL, branch, and path in the original issue.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
![image](https://github.com/common-workflow-language/cwlviewer/assets/1330696/aa0d3d0e-2751-4f88-93f8-ec0f0a5fe9f8)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
